### PR TITLE
chore: add `.notes` dir, License and rename map name (outdated)

### DIFF
--- a/.notes/RiRi Explained (mostly).md
+++ b/.notes/RiRi Explained (mostly).md
@@ -1,0 +1,3 @@
+`TODO`
+
+On MVP ready -> Benchmark

--- a/.notes/optimisation_choices/function pointers over std.function and lambdas.md
+++ b/.notes/optimisation_choices/function pointers over std.function and lambdas.md
@@ -1,0 +1,65 @@
+# Function Pointers over `std::function` and Lambda Functions
+*Function pointers may not be cooler, but they are definitely faster when all you need is raw speed and an overall less memory usage.*
+
+## Context
+Currently, [`CommandParser.h`](../../include/CommandParser.h) defines a function pointer type as follows:
+```cpp
+// CommandParser.h at line: 23
+using RiRiCommandFn = std::string(*)(const std::vector<std::string_view>&);
+```
+Which defines the function pointer type and is used as the parameter type for our `ankerl::unordered_dense:map<...> ririCommandMap`'s value type (see [`CommandParser.h`](../../include/CommandParser.h): line 46).
+
+Functions are defined based on the parameters and return type of the function pointer and then emplaced in `ririCommandMap` with corresponding `COMMAND` strings (see [`CommandParser.cpp`](../../src/CommandParser.cpp): line 149).
+
+Initially however, something much cooler was used.
+```cpp
+using RiRiCommandFn = std::function<std::string(const std::vector<std::string>&)
+```
+`std::function` introduced in C++11: 
+This was used to give the parameter type for the same `ririCommandMap` as discussed above. And:
+
+```cpp
+riricommands.emplace("SET", [dataStore](const std::vector<std::string>& args) { 
+    if (args.size() != 2) return "ERROR: SET needs key and value";
+    dataStore->setValue(args[0], args[1]);
+    return "OK";
+});
+
+riricommands.emplace("GET", [dataStore](const std::vector<std::string>& args) { 
+    if (args.size() != 1) return std::string("ERROR: GET needs key");
+    return dataStore->getValue(args[0]);
+});
+```
+Yes, __Lambda Functions__ (more like nameless functions) were used, which allowed me to define and emplace both at the same time, it also made the implemntation look a lot cleaner and was more secure (encapsualtion, ~~though I am not so sure about the secure part~~).
+
+This avoided defining and emplacing the functions separately (using function pointers), which requires more boilerplate when compared to inline lambdas using `std::function`.
+
+## So, why not `std::function` anymore?
+
+As previously stated, commands were stored using std::function and lambdas in a string-to-function map. However, profiling showed that it introduces overhead due to:
+
+ - I do not yet know how, but potential heap allocations (likely from **type erasure** or **dynamic storage**).
+ - Type erasure logic (polymorphism essentially, we don't need that)
+ - Larger Objects because `std::function` is typically 32+ bytes.
+
+Since, *we do NOT need capturing lambdas* (although they are cool), and we are mostly working with global/static functions, we are using **function pointers** instead. Oh and capturing lambdas are in itself a memory overhead as well.
+
+### Initial Metrics
+| Iterations   | `std::function` | function pointer | Difference %     |
+|:------------:|:---------------:|:----------------:|:----------------:|
+| 1 million    | 137.191 ms      | 134.613 ms       | ~1.88% faster    |
+| 1.4 billion  | 202236 ms       | 189615 ms        | ~6.2% faster     |
+
+Compiler Used: `Clang++` with `lld`.
+
+Sure, this isn't a deal-breaking change — I don't expect RiRi to deal with 1.4 billion commands.
+But the difference is clear. Plus, since we are not capturing lambdas memory usage is expected to be lower.
+
+### *"Expected? Where are the metrics?"* you might ask
+
+`TODO:`
+Well, I wasn't able to benchmark the memory usage due to the limited number of commands and lack of its code/logic cleanup during the inital testing. So, as soon as the command parser is ready (which it almost is), I will add the metrics for memory usage as well.
+
+**NOTE:** The profiling was done with all optimisation enabled (`-O3`, `-flto`, `-march=native` and `-fuse-ld=lld`) to simulate real world usage. Additionally, these metrics are without the use of `std::string_view` as I didn't use it originally with the initial implementation.
+
+*Loosely inspired by how Redis dispatches commands via raw function pointers in C.*

--- a/.notes/optimisation_choices/string_view over string.md
+++ b/.notes/optimisation_choices/string_view over string.md
@@ -1,0 +1,1 @@
+`TODO` w/metrics, soon.

--- a/.notes/optimisation_choices/unordered_dense over unordered_map.md
+++ b/.notes/optimisation_choices/unordered_dense over unordered_map.md
@@ -1,0 +1,5 @@
+`TODO`
+
+However, I do have enough reliable metrics showing that `ankerl::unordered_dense::map` was simply better, which was the leading cause for this optimization.
+
+also `TODO`: Research and understand how `ankerl::unordered_dense::map` actually works.

--- a/License.md
+++ b/License.md
@@ -1,0 +1,59 @@
+# RiRi Rapid Dev License (RRDL) v1.0  
+**© 2025 Adarsh Aryan (Shadow's Lure)**  
+Rapid In-Memory Redis Interface — RiRi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software” or “RiRi”), to use, copy, modify, merge, and distribute the Software, subject to the following conditions:
+
+-------------------------------------------------------------------------------
+### 1. Attribution Requirements
+- You must retain this copyright notice and license in all copies or substantial portions of the Software.
+- You must clearly credit the original author (“Adarsh Aryan”) and the project name “RiRi” in your project’s documentation, README file, or license/acknowledgments section.
+- Credit format should include: "Powered by RiRi by Adarsh Aryan" or equivalent clear attribution.
+- No attribution is required in user interfaces or end-user facing materials.
+
+-------------------------------------------------------------------------------
+### 2. Commercial Use
+
+- **Permitted**: Use RiRi as a component, dependency, or backend service in commercial or enterprise software.  
+- **Prohibited**: You may not sell, license, or distribute RiRi itself (or substantially similar versions) as a standalone commercial product or service.
+
+- Attribution is **required** in all cases of commercial use (see Section 1).
+
+Examples:
+- Allowed: Using RiRi as your application's database backend
+- Allowed: Embedding RiRi in your commercial software suite
+- Not allowed: Selling RiRi as “YourDB Pro” or similar standalone database product
+
+-------------------------------------------------------------------------------
+### 3. Distribution & Modification
+
+- You may fork, modify, and redistribute RiRi for any lawful purpose.
+- Modified versions must retain this license and the attribution terms.
+- You may distribute modified versions under these same license terms.
+
+-------------------------------------------------------------------------------
+### 4. Naming Rights & Brand Protection
+
+- You may **not** use “RiRi” or any confusingly similar to “RiRi” in your product, fork, or service name without written permission.
+- Including but not limited to `RiRi-[suffix]`, `[prefix]-RiRi`, `RiRiDB`, `RiRiX`.
+- You **may** use unrelated names like “MemoryCache”, “LiteStore”, etc.
+
+This restriction applies to project names, product branding, and marketing materials.
+
+-------------------------------------------------------------------------------
+### 5. Patent Grant
+
+Contributors and users of this Software grant each other a perpetual, worldwide, non-exclusive, no-charge, royalty-free patent license to make, use, sell, and distribute the Software, subject to the terms of this license.
+
+-------------------------------------------------------------------------------
+### 6. Liability Disclaimer
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+**RiRi Rapid Dev License (RRDL) v1.0** : Fast paced quality development first, legality handled.
+
+For questions, permissions, or contributions, visit:  https://github.com/ad4rsh2701/RiRi
+
+**Adarsh Aryan** a.k.a. **Shadow's Lure**, 2025

--- a/include/CommandParser.h
+++ b/include/CommandParser.h
@@ -1,5 +1,11 @@
-// TODO:
-// Add more commands
+/**
+ * @file CommandParser.h
+ * @author Adarsh Aryan (adarsharyan2701@gmail.com)
+ * @brief 
+ * 
+ * @copyright Copyright (c) 2025
+ * 
+ */
 
 #pragma once
 #include <string>
@@ -7,71 +13,183 @@
 #include "DataStore.h"
 #include "ankerl/unordered_dense.h"
 
-// Global Pointer to the DataStore instance
-extern DataStore* g_dataStore;
 
-// Function pointer type for commands
+/**
+ * @brief Function pointer type used for RiRi command functions.
+ * 
+ * Each command function takes a list of `string_view` arguments,
+ * and returns a result `string` (output or status).
+ */
 using RiRiCommandFn = std::string(*)(const std::vector<std::string_view>&);
 
+/**
+ * @class CommandParser
+ * @brief Responsible for parsing and executing commands on the RiRi datastore.
+ */
 class CommandParser {
 private:
 
-    // Previous Implementation(the cool Lambdas):
-    // ankerl::unordered_dense::map<
-    //     std::string_view,
-    //     std::function<std::string(const std::vector<std::string>&)>
-    // > riricommands;
+    /**
+     * @brief Mapping from command name to function pointer.
+     * 
+     * Supports aliases and function pointer-based fast dispatch.
+     * /
+     * @note `ankerl:unordered_dense` is used as a drop-in replacement for `std::unordered_map`.
+     *        It provides much faster insertion/search and occupies far less memory.
+     */
+    ankerl::unordered_dense::map<std::string_view, RiRiCommandFn> ririCommandMap;
 
-    // Current Mapping using simple plain function pointers
-    ankerl::unordered_dense::map<std::string_view, RiRiCommandFn> riricommands;
+    /**
+     * @brief Parses a raw command string into individual tokens.
+     * 
+     * @param command Full user command (e.g., "SET key value"), space-delimited.
+     * @return Vector of parsed tokens (command + args) of the type `string_view`.
+     * @note The returned `string_view`s are safe to use because they point into
+     *       the original `command` input, which remains alive during usage in
+     *       `executeCommand()`. Tokens are not stored long-term.
+     */
     std::vector<std::string_view> parseCommand(std::string_view command) const; // Parse and validate commands
 
 public:
+    
+    /**
+     * @brief Constructs a CommandParser and initializes the command map.
+     * 
+     * @param ds Pointer to the main RiRi datastore.
+     */
     explicit CommandParser(DataStore* ds); // Constructor
+
+    /**
+     * @brief Executes a full user command.
+     * 
+     * Parses and tokenizes the input command string, strips the command name
+     * (i.e., the first token), and dispatches the remaining arguments to the
+     * corresponding function mapped in `ririCommandMap`.
+     * 
+     * Example: "SET key7 RiRiIsAwesome" → calls `setCommand({"key7", "RiRiIsAwesome"})`
+     * 
+     * @param command Full user command (e.g., "SET key value"), space-delimited.
+     * @return Result string to be printed or sent back to the client.
+     */
     std::string executeCommand(std::string_view command) const; // Execute commands on the DataStore
 };
 
-// RiRi Commands
+
+// Respective Command Functions
+
+//SET
+/**
+ * @brief Sets a key to a value. Also supports bulk key-value pairs.
+ * @param args Parsed arguments. Accepts:
+ *
+ * - Single PAIR: `{ key, value }`
+ * 
+ * - Bulk PAIR: `{ key1, value1, key2, value2, ... }`
+ * @return "OK" if successful, or error message for malformed input.
+ * @note The command name (`SET`) is already removed before this function is called.
+ *       The args vector only contains the remaining arguments.
+ */
 std::string setCommand(const std::vector<std::string_view>& args);
+
+//GET
+/**
+ * @brief Retrieves the value(s) associated with one or more keys.
+ * @param args Parsed arguments (command name removed). Accepts:
+ *        
+ * - Single KEY: `{ key }`
+ *        
+ * - Bulk KEYS:   `{ key1, key2, key3, ... }`
+ * @return The value(s) associated with the key(s), or error messages for missing keys.
+ * @note The command name (`GET`) is already removed before this function is called.
+ *       The args vector only contains the remaining arguments.
+ */
 std::string getCommand(const std::vector<std::string_view>& args);
+
+//UPDATE
+/**
+ * @brief Updates existing key(s) with new value(s).
+ * @param args Parsed arguments. Accepts:
+ *        
+ * - Single: `{ key, newValue }`
+ *        
+ * - Bulk:   `{ key1, newVal1, key2, newVal2, ... }`
+ * @return "OK" with a count of updated keys, or an error message.
+ * @note - Keys must already exist; this does not create new ones.
+ * @note - The command name (`UPDATE`) is already removed before this function is called.
+ *       The args vector only contains the remaining arguments.
+ */
 std::string updateCommand(const std::vector<std::string_view>& args);
+
+//DELETE
+/**
+ * @brief Deletes one or more key-value pairs from the datastore.
+ * @param args Parsed arguments. Vector of keys to delete. Accepts:
+ *         
+ * - Single: `{ key }`
+ *        
+ * - Bulk: `{ key1, key2, key3, ... }`
+ * @return "OK (N deleted)" where N is the number of keys successfully removed.
+ * @note - Keys must already exist; there is no blackmagic which deletes non-existing keys.
+ * @note - The command name (`DELETE` or `DEL`) is already removed before this function is called.
+ *         The args vector only contains the remaining arguments.
+ */
 std::string deleteCommand(const std::vector<std::string_view>& args);
+
+//GET_ALL
+/**
+ * @brief Returns the entire key-value datastore as a formatted string.
+ *
+ * @param args Should be empty.
+ * @return A formatted list of key-value pairs, or "EMPTY" if the store is empty.
+ *
+ * @note - Any unexpected arguments will result in an error.
+ * @note - The command name (`GET_ALL` or `DUMP`) is already removed before this function is called.
+ *         The args vector should be empty.
+ */
 std::string getAllCommand(const std::vector<std::string_view>& args);
+
+// CLEAR
+/**
+ * @brief Clears all data from the datastore.
+ *
+ * @param args Should be empty.
+ * @return "OK (cleared)" on success, or an error if arguments are passed.
+ * @note - Any unexpected arguments will result in an error.
+ * @note - The command name (`CLEAR` or `CLR`) is already removed before this function is called.
+ *         The args vector should be empty.
+ */
 std::string clearCommand(const std::vector<std::string_view>& args);
+
+// AUTOSET
+/**
+ * @brief ## Note: Implementation Remaining
+ * @brief Sets values to auto-generated keys using a hash-based scheme.
+ *
+ * @param args One or more `values`. Each value will be stored under a unique auto-generated key.
+ * @return "OK (N auto-keys set)" where N is the number of values processed (expected).
+ *
+ * @note - Ideal for quick data dumps or logging without naming keys manually.
+ * @note - The command name (`AUTOSET` or `HASH_SET`) is already removed before this function is called.
+ *       The args vector only contains the remaining arguments (values).
+ */
 std::string autoSetCommand(const std::vector<std::string_view>& args);
+
+// SEARCH
+/**
+ * @brief ## Note: Optimization Remaining
+ * @brief Searches the datastore for all keys associated with a specific value.
+ *
+ * @param args Should contain at least one value to search for. Accepts:
+ *         
+ * - Single: `{ value }`
+ *        
+ * - Bulk: `{ val1, val2, val3, ... }`
+ * @return A list of matching keys, or "key: (not found)".
+ *
+ * @note - This operation performs a full scan of the datastore (O(N)).
+ *         It may be slow with large datasets.
+ * @note - The command name (`SEARCH` or `FIND_BY_VALUE`) is already removed before this function is called.
+ *         The args vector only contains the remaining arguments (values).
+ */
 std::string searchCommand(const std::vector<std::string_view>& args);
 
-// So, why not std::function?
-
-// Originally, commands were stored using std::function and lambdas in a string-to-function map.
-// However, profiling showed that it introduces overhead due to:
-// 
-//  - I do not know how, but potential heap allocations (likely from type erasure or dynamic storage).
-//  - Type erasure logic (polymorphism essentially, we don't need that)
-//  - Larger Objects because std::function is typical 32+ bytes.
-//
-// Since we do NOT need capturing lambdas (although they are cool), and we are mostly working
-// with global/static functions, we are using function pointers instead.
-//
-// Metrics:
-// Iterations   std::function   function pointer    % Difference
-// 1 million    137.191 ms      134.613 ms          ~1.88% faster
-// 1.4 billion  202,236 ms      189,615 ms          ~6.2% faster
-//
-// Sure, this isn't a deal-breaking change — I don't expect RiRi to deal with 1.4 billion commands.
-// But the difference is clear. Plus, since we are not capturing lambdas memory usage is expected
-// to be lower.
-
-// Expected? Where are the metrics?
-// I wasn't able to benchmark the memory usage due to the limited number of commands and lack of
-// its code/logic cleanup. So, as soon as the command parser is ready, I will add the metrics for
-// memory usage as well.
-//
-// Compiler Used: Clang++
-// NOTE: The profiling was done with all optimisation enabled ("-O3", "-flto", "-march=native"
-// and "-fuse-ld=lld") to simulate real world usage. Additionally, these metrics are without the
-// use of `std::string_view` as I have yet to implement it properly.
-//
-// Loosely inspired by how Redis dispatches commands via raw function pointers in C.
-
-// Also TODO: After getting the updated metrics, move it to readme.

--- a/include/DataStore.h
+++ b/include/DataStore.h
@@ -1,29 +1,28 @@
 // DataStore.h
-#ifndef DATA_STORE_H
-#define DATA_STORE_H
 
+#pragma once
 #include <unordered_map>
 #include <string>
 #include "ankerl/unordered_dense.h"
 
 class DataStore {
 private:
-    //std::unordered_map<std::string, std::string> data; // Key-value store
-    ankerl::unordered_dense::map<std::string, std::string> data;
+    //std::unordered_map<std::string, std::string> data; 
+    ankerl::unordered_dense::map<std::string, std::string> data;            // Key-value store
+    
 public:
-    void setValue(const std::string& key, const std::string& value);    // Set key-value pair
+    void setValue(const std::string& key, const std::string& value);        // Set key-value pair
     
-    std::string getValue(const std::string& key) const;                       // Get value by key
+    std::string getValue(const std::string& key) const;                     // Get value by key
     
-    bool deleteValue(const std::string& key);                           // Delete a key
-    bool updateValue(const std::string& key, const std::string& value); // Update value by key
+    bool deleteValue(const std::string& key);                               // Delete a key
+    
+    bool updateValue(const std::string& key, const std::string& value);     // Update value by key
 
-    // std::unordered_map<std::string, std::string> returnData();          // Return all data
-    ankerl::unordered_dense::map<std::string, std::string> returnData();
+    // std::unordered_map<std::string, std::string> returnData();
+    ankerl::unordered_dense::map<std::string, std::string> returnData();    // Return all data
     
     std::string getKey(const std::string& value) const;
     
-    void clearData();                                                   // Clear all data
+    void clearData();                                                       // Clear all data
 };
-
-#endif // DATA_STORE_H

--- a/src/CommandParser.cpp
+++ b/src/CommandParser.cpp
@@ -8,17 +8,15 @@
 // implementation of string-to-function map, as discussed in the
 // CommandParser.h header file. More details given later below.
 
-#include "../include/CommandParser.h"
+#include "CommandParser.h"
 
-DataStore* g_dataStore = nullptr;  // initializing
+// Global pointer to the DataStore instance used by all command functions.
+DataStore* g_dataStore = nullptr;
 
 // We will use typical functions, instead of lambda functions.
 
-// SET fn()
+
 std::string setCommand(const std::vector<std::string_view>& args) {
-    // if (args.size() != 2) return "ERROR: SET needs key and value";
-    // g_dataStore->setValue(std::string(args[0]), std::string(args[1]));  // Direct global access is BETTER
-    // return "OK";
     if (args.size() == 2) {
         g_dataStore->setValue(std::string(args[0]), std::string(args[1]));
         return "OK";
@@ -34,10 +32,8 @@ std::string setCommand(const std::vector<std::string_view>& args) {
     }
 }
 
-// GET fn()
+
 std::string getCommand(const std::vector<std::string_view>& args){
-    // if (args.size()!=1) return "ERROR: GET needs key";
-    // return g_dataStore->getValue(std::string(args[0]));  // just better
     if (args.size() == 1){ return g_dataStore -> getValue(std::string(args[0])); }
     else if (args.size() > 1){
         std::string result;
@@ -50,11 +46,10 @@ std::string getCommand(const std::vector<std::string_view>& args){
     }
 }
 
-// UPDATE fn()
+
 std::string updateCommand(const std::vector<std::string_view>& args){
     if (args.size() == 2) {
-        // I am so sorry
-        return g_dataStore->updateValue(std::string(args[0]), std::string(args[1])) ? "OK" : "ERROR: Key not found";
+        return g_dataStore->updateValue(std::string(args[0]), std::string(args[1])) ? "OK" : "ERROR: Key not found";    // I am so sorry
     } else if (args.size() > 2 && args.size() % 2 == 0) {
         int updated = 0;
         for (size_t i = 0; i < args.size(); i += 2) {
@@ -70,10 +65,9 @@ std::string updateCommand(const std::vector<std::string_view>& args){
     }
 }
 
-// DELETE fn()
+
 std::string deleteCommand(const std::vector<std::string_view>& args) {
     if (args.size()==1) {
-        // sorry, again
         return g_dataStore->deleteValue(std::string(args[0])) ? "OK (1 deleted)" : "ERROR: Key not found";
     } else if (args.size() > 1){
         int deleted = 0;
@@ -88,7 +82,7 @@ std::string deleteCommand(const std::vector<std::string_view>& args) {
 }
 
 
-// GET_ALL fn()
+
 std::string getAllCommand(const std::vector<std::string_view>& args) {
     if (!args.empty()) return "ERROR: GET_ALL does not accept arguments";
 
@@ -135,13 +129,13 @@ std::string searchCommand(const std::vector<std::string_view>& args) {
 CommandParser::CommandParser(DataStore* dataStore) {
     g_dataStore = dataStore;
     
-    // riricommands.emplace("SET", [&dataStore](const std::vector<std::string>& args) { 
+    // ririCommandMap.emplace("SET", [&dataStore](const std::vector<std::string>& args) { 
     //     if (args.size() != 2) return "ERROR: SET needs key and value";
     //     g_dataStore->setValue(args[0], args[1]);
     //     return "OK";
     // });
     
-    // riricommands.emplace("GET", [&dataStore](const std::vector<std::string>& args) { 
+    // ririCommandMap.emplace("GET", [&dataStore](const std::vector<std::string>& args) { 
     //     if (args.size() != 1) return std::string("ERROR: GET needs key");
     //     return g_dataStore->getValue(args[0]);
     // });
@@ -152,22 +146,22 @@ CommandParser::CommandParser(DataStore* dataStore) {
     // to other functions. I didn't consider the overhead of this appraoch at that time.
 
     // Commands
-    riricommands.emplace("SET", setCommand);
-    riricommands.emplace("GET", getCommand);
-    riricommands.emplace("UPDATE", updateCommand);
-    riricommands.emplace("DELETE", deleteCommand);
-    riricommands.emplace("GET_ALL", getAllCommand);
-    riricommands.emplace("CLEAR", clearCommand);
-    riricommands.emplace("AUTOSET", autoSetCommand);
-    riricommands.emplace("SEARCH", searchCommand);
+    ririCommandMap.emplace("SET", setCommand);
+    ririCommandMap.emplace("GET", getCommand);
+    ririCommandMap.emplace("UPDATE", updateCommand);
+    ririCommandMap.emplace("DELETE", deleteCommand);
+    ririCommandMap.emplace("GET_ALL", getAllCommand);
+    ririCommandMap.emplace("CLEAR", clearCommand);
+    ririCommandMap.emplace("AUTOSET", autoSetCommand);
+    ririCommandMap.emplace("SEARCH", searchCommand);
     
     // Command Aliases
-    riricommands.emplace("DEL", riricommands.at("DELETE"));
-    riricommands.emplace("DUMP", riricommands.at("GET_ALL"));
-    riricommands.emplace("CLR", riricommands.at("CLEAR"));
-    riricommands.emplace("YEET", riricommands.at("CLEAR"));
-    riricommands.emplace("HASH_SET", riricommands.at("AUTOSET"));
-    riricommands.emplace("FIND_BY_VALUE", riricommands.at("SEARCH"));
+    ririCommandMap.emplace("DEL", ririCommandMap.at("DELETE"));
+    ririCommandMap.emplace("DUMP", ririCommandMap.at("GET_ALL"));
+    ririCommandMap.emplace("CLR", ririCommandMap.at("CLEAR"));
+    ririCommandMap.emplace("YEET", ririCommandMap.at("CLEAR"));
+    ririCommandMap.emplace("HASH_SET", ririCommandMap.at("AUTOSET"));
+    ririCommandMap.emplace("FIND_BY_VALUE", ririCommandMap.at("SEARCH"));
 
 }
 
@@ -211,8 +205,8 @@ std::string CommandParser::executeCommand(std::string_view command) const {
     std::string_view commandName = tokens[0];
     tokens.erase(tokens.begin());  // Remove command name from args
 
-    auto it = riricommands.find(commandName);
-    if (it == riricommands.end()) return "ERROR: Unknown command";
+    auto it = ririCommandMap.find(commandName);
+    if (it == ririCommandMap.end()) return "ERROR: Unknown command";
 
     return it->second(tokens);  // Call the function stored in the map
 }

--- a/src/DataStore.cpp
+++ b/src/DataStore.cpp
@@ -1,9 +1,9 @@
 // #include <unordered_map>
-#include "../include/ankerl/unordered_dense.h"
+#include "ankerl/unordered_dense.h"
 #include <string>
-#include "../include/DataStore.h" // Include the header file
+#include "DataStore.h" // Include the header file
 
-// CRUD operations
+
 void DataStore::setValue(const std::string& key, const std::string& value){
     data[key] = value;
 } // CREATE

--- a/src/PersistenceEngine.cpp
+++ b/src/PersistenceEngine.cpp
@@ -1,8 +1,8 @@
 #include <fstream>
 #include <string>
 #include <sstream>
-#include "../include/DataStore.h"
-#include "../include/PersistenceEngine.h" // Include the header file
+#include "DataStore.h"
+#include "PersistenceEngine.h"
 
 PersistenceEngine::PersistenceEngine(DataStore* dataStore) {
     this->dataStore = dataStore;


### PR DESCRIPTION
Added:
- `.notes` folder: This will hold several .md explaining my development choices and other code unrelted stuff.
- Document Strings (docstrings) or essentally in code documentation to CommandParser.h

Update:
- Renamed `ririCommands` to `ririCommandMap` for better clarity.
- `License.md` now hosts our shiny new license `RRDL v1.0`, let's go!
- Other spacing and formatting changes that git loves tracking so much.