### PR TITLE
refactor: change key type to `std::string` and fix redundant allocation in Data Manager via move semantics

### DIFF
--- a/src/core/DataManager.cpp
+++ b/src/core/DataManager.cpp
@@ -2,8 +2,8 @@
 
 using namespace RiRi;
 
-bool Internal::setValue(std::string_view key, const RapidDataType& value) noexcept {
-    return Internal::MemoryMap.insert({key, value}).second;
+bool Internal::setValue(std::string&& key, const RapidDataType& value) noexcept {
+    return Internal::MemoryMap.insert({std::move(key), value}).second;
 }
 
 

--- a/src/core/MemoryMaps.cpp
+++ b/src/core/MemoryMaps.cpp
@@ -8,13 +8,13 @@ using namespace RiRi;
 ankerl::unordered_dense::map<
     std::string,
     RapidDataType,
-    ankerl::unordered_dense::hash<std::string>,
+    RapidHash,
     std::equal_to<>
 > Internal::MemoryMap = [] {
     ankerl::unordered_dense::map<
         std::string,
         RapidDataType,
-        ankerl::unordered_dense::hash<std::string>,
+        RapidHash,
         std::equal_to<>
     > map;
     map.reserve(DEFAULT_MEMORY_CAPACITY);
@@ -28,13 +28,13 @@ ankerl::unordered_dense::map<
 ankerl::unordered_dense::map<
     std::string,
     RapidCommandFn,
-    ankerl::unordered_dense::hash<std::string>,
+    RapidHash,
     std::equal_to<>
 > Internal::AuxCommandMap = [] {
     ankerl::unordered_dense::map<
         std::string,
         RapidCommandFn,
-        ankerl::unordered_dense::hash<std::string>,
+        RapidHash,
         std::equal_to<>
     > map;
     map.reserve(DEFAULT_COMMAND_CAPACITY);

--- a/src/core/MemoryMaps.cpp
+++ b/src/core/MemoryMaps.cpp
@@ -6,15 +6,15 @@ constexpr size_t DEFAULT_COMMAND_CAPACITY = 16;
 using namespace RiRi;
 
 ankerl::unordered_dense::map<
-    std::string_view,
+    std::string,
     RapidDataType,
-    ankerl::unordered_dense::hash<std::string_view>,
+    ankerl::unordered_dense::hash<std::string>,
     std::equal_to<>
 > Internal::MemoryMap = [] {
     ankerl::unordered_dense::map<
-        std::string_view,
+        std::string,
         RapidDataType,
-        ankerl::unordered_dense::hash<std::string_view>,
+        ankerl::unordered_dense::hash<std::string>,
         std::equal_to<>
     > map;
     map.reserve(DEFAULT_MEMORY_CAPACITY);
@@ -26,15 +26,15 @@ ankerl::unordered_dense::map<
 }();
 
 ankerl::unordered_dense::map<
-    std::string_view,
+    std::string,
     RapidCommandFn,
-    ankerl::unordered_dense::hash<std::string_view>,
+    ankerl::unordered_dense::hash<std::string>,
     std::equal_to<>
 > Internal::AuxCommandMap = [] {
     ankerl::unordered_dense::map<
-        std::string_view,
+        std::string,
         RapidCommandFn,
-        ankerl::unordered_dense::hash<std::string_view>,
+        ankerl::unordered_dense::hash<std::string>,
         std::equal_to<>
     > map;
     map.reserve(DEFAULT_COMMAND_CAPACITY);

--- a/src/include/DataManager.h
+++ b/src/include/DataManager.h
@@ -33,7 +33,7 @@ namespace RiRi::Internal {
      * 
      * @note Returns `true` if the key-value pair was successfully inserted, `false` if the key already exists or the insertion failed (very unlikely).
      */
-    GO_AWAY bool setValue(std::string_view key, const RapidDataType& value) noexcept;
+    GO_AWAY bool setValue(std::string&& key, const RapidDataType& value) noexcept;
 
 
     /**

--- a/src/include/MemoryMaps.h
+++ b/src/include/MemoryMaps.h
@@ -28,7 +28,7 @@ namespace RiRi::Internal {
     /**
      * @brief ### Main Memory Map for Rapid Data Access
      * 
-     * This map uses `std::string_view` as keys and `RapidDataType` as values.
+     * This map uses `std::string` as keys and `RapidDataType` as values.
      * It is designed for fast lookups and efficient memory usage.
      * 
      * The map is initialized with a reserved size to optimize performance.
@@ -38,13 +38,13 @@ namespace RiRi::Internal {
      * @see RapidDataType for the types of values stored in this map.
      */
     GO_AWAY extern ankerl::unordered_dense::map<
-        std::string_view,
+        std::string,
         RapidDataType,
         ankerl::unordered_dense::hash<std::string_view>,
         std::equal_to<>
     > MemoryMap;
     // Yes, I leveled up and am using ankerl::unordered_dense::map with hash and equality
-    // functions for std::string_view, as intended.
+    // functions for std::string, as intended. This allows us for fast lookups using std::string_view keys.
     // Previously, I just used ankerl::unordered_dense::map<std::string, std::string>, which was definitely not optimal.
 
 
@@ -52,7 +52,7 @@ namespace RiRi::Internal {
     /**
      * @brief ### Auxiliary Command Function Pointer Map
      * 
-     * This map associates command names (as `std::string_view`) with their corresponding
+     * This map associates command names (as `std::string`) with their corresponding
      * function pointers of type `RapidCommandFn`. 
      * 
      * - Used for auxiliary command handling.
@@ -66,9 +66,9 @@ namespace RiRi::Internal {
      * @see Commands.h for the list of available commands and their implementations.
      */
     GO_AWAY extern ankerl::unordered_dense::map<
-        std::string_view,
+        std::string,
         RapidCommandFn,
-        ankerl::unordered_dense::hash<std::string_view>,
+        ankerl::unordered_dense::hash<std::string>,
         std::equal_to<>
     > AuxCommandMap;
 

--- a/src/include/MemoryMaps.h
+++ b/src/include/MemoryMaps.h
@@ -40,12 +40,19 @@ namespace RiRi::Internal {
     GO_AWAY extern ankerl::unordered_dense::map<
         std::string,
         RapidDataType,
-        ankerl::unordered_dense::hash<std::string>,
+        RapidHash,
         std::equal_to<>
     > MemoryMap;
     // Yes, I leveled up and am using ankerl::unordered_dense::map with hash and equality
     // functions for std::string, as intended. This allows us for fast lookups using std::string_view keys.
     // Previously, I just used ankerl::unordered_dense::map<std::string, std::string>, which was definitely not optimal.
+
+    // Levelled up AGAIN:
+    // Now using ankerl::unordered_dense::map<std::string, RapidDataType> with a custom hash and equality function.
+    // This allows us to store various types of data in the map, including strings, integers, doubles, and booleans.
+    // Why a custom hash and equality function?
+    // Because ankerl::unordered_dense::map does not support transparent hash and equality functions,
+    // and neither does clang's libc++.
 
 
 
@@ -68,7 +75,7 @@ namespace RiRi::Internal {
     GO_AWAY extern ankerl::unordered_dense::map<
         std::string,
         RapidCommandFn,
-        ankerl::unordered_dense::hash<std::string>,
+        RapidHash,
         std::equal_to<>
     > AuxCommandMap;
 

--- a/src/include/MemoryMaps.h
+++ b/src/include/MemoryMaps.h
@@ -40,7 +40,7 @@ namespace RiRi::Internal {
     GO_AWAY extern ankerl::unordered_dense::map<
         std::string,
         RapidDataType,
-        ankerl::unordered_dense::hash<std::string_view>,
+        ankerl::unordered_dense::hash<std::string>,
         std::equal_to<>
     > MemoryMap;
     // Yes, I leveled up and am using ankerl::unordered_dense::map with hash and equality


### PR DESCRIPTION
Resolves #11 (REFACTOR - CRITICAL - Potential extra string allocations and unjustified use of string_view as keys for the map)

I want to sleep. So, here's a quick review of what fixes this PR introduces to address the CRITICAL issue:

1. As per the issue, `key`s in `MemoryMap` and `AuxCommandMap` are now of the type `std::string` instead of `std::string_view`. This was done so to avoid extra string allocations.
2. The helper functions, especially the `setValue()` function, now takes `std::string&&` key types as one of its parameters, assuming a string allocation of this somewhere in the upper layer function. Next, this allocation is essentially moved into the map directly by changing the ownership of it. This was done so by making the now `std::string&&` type key _open to ownership_, essentially letting the compiler know that "I’m done using key — feel free to treat it as a temporary and steal its contents". This was achieved by using a classic C++11 function; `std::move()`.

The tagged issue descriptions does a much better job of detailing these changes (refer #11).

Now, there is another change, an unexpected one:

Initially, before the Issue, the `MemoryMap` map was defined like so:
```cpp
    GO_AWAY extern ankerl::unordered_dense::map<
        std::string_view,
        RapidDataType,
        ankerl::unordered_dense::hash<std::string_view>,
        std::equal_to<>
    > MemoryMap;
```
Ignore the `string_view` danger (which this PR fixes) for now, and assume that this did work, somehow. And previously, all our helper functions worked with `string_view` keys.

So, the map always received the correct types, hence, the heterogenous lookup was never needed/called for, even though it was implemented, and my IntelliSense never complained about the impending doom.

But, when I updated keys to be of the correct type like so:

```cpp
    GO_AWAY extern ankerl::unordered_dense::map<
        std::string,
        RapidDataType,
        ankerl::unordered_dense::hash<std::string>,
        std::equal_to<>
    > MemoryMap;
```

Suddenly, all my helper functions were marked with red squiggles (IntelliSense's way of saying: "There are errors"). I mean, it made sense for the setValue() function, as it needed to insert `string` keys now, not `string_view` but the other helpers should have been fine?

After a few fix ATTEMPTS (modifying the `setValue()` to use `string&& key` and `std::move()`), still error indicators. Even on, what should have been, a fixed `setValue()`. 

This signaled two insights:
1. `ankerl::unordered_dense::map` would only accept `std::string` keys, which will require an additional allocation on every helpers.
2. Which implies that the heterogeneous lookup was definitely not working.

Here is what was previously implemented to support heterogenous lookup:
```cpp
        ....
        ankerl::unordered_dense::hash<std::string>,
        std::equal_to<>
        ...
```

We passed a hash function (again from `ankerl::unordered_dense`, it's better, I benchmarked) which will support hashing for both `std::string` and `std::string_view`, transparently (i.e. without any allocation; what I inferred).

And then we passed `std::equal_to<>` (note the empty angle brackets), which allows equality comparisons between different string types like `std::string` and `std::string_view`.

THIS ASSUMES, THAT `ankerl::unordered_dense::hash` HAS SUPPORT FOR HASHING BOTH THE TYPES WITHOUT ANY ALLOCATION.

Which, if it was an `std::unordered_map::hash`, would be valid, but apparently, purely because I was consistently getting errors, `ankerl::unordered_dense::hash` DOES NOT SUPPORT THIS ASSUMPTION.

If all this makes little sense, then wait for an extremely detailed note POST MVP, explaining this. For now (in a matter-of-fact way) just know that `ankerl::unordered_dense::hash` does not support heterogenous lookup inherently :(

Again, I cannot say this concretely, so if you find a way to do so, send a PR.

I resolved this, uncomfortably, by introducing a wrapper —like struct which, based on the key type, overloaded the hash map.
The commit 6ee904e gives a bit more briefing on this (I know I said I will give more details here, but instead wait for the note mentioned above, it will directly address this issue, will likely go under `.notes/issues_notes/`, a new folder). 

I actually, benchmarked a lot on this, and for almost the entire day (again, seems like new normal now). But, show casing those here, is beyond the scope of this PR message (as it includes another new custom `struct` which replaced `std::equal_to`, as it was debugged as the potential issue first —until it wasn't), the note, mentioned above, will likely show these benchmark results in detail (_when a `bench.exe` takes 12GB of RAM_).

That's all! Thank you for reading all this —if you did that is. 

Oh well it crossed 00:00 anyways.

