### PR TITLE
feat: add support for heterogeneous lookup via `RapidHash` correctly

### DIFF
--- a/.notes/optimisation_choices/string_view over string.md
+++ b/.notes/optimisation_choices/string_view over string.md
@@ -1,5 +1,11 @@
 # `std::string_view` over `std::string`: A surprisingly tricky optimization
 
+> ## OUTDATED & INCORRECT FACTS
+> This optimisation note is OUTDATED and presents some wrong facts, brought to light by external validation.
+>
+> However, the general opinion on `string_view` is still valid.
+> An update to this note is in the works.
+
 *I am still not sure whether my current version is the most optimal, that's how much there is to this optimization.*
 
 ## Context: The problem with `std::string`

--- a/src/include/MemoryMaps.h
+++ b/src/include/MemoryMaps.h
@@ -48,11 +48,11 @@ namespace RiRi::Internal {
     // Previously, I just used ankerl::unordered_dense::map<std::string, std::string>, which was definitely not optimal.
 
     // Levelled up AGAIN:
-    // Now using ankerl::unordered_dense::map<std::string, RapidDataType> with a custom hash and equality function.
+    // Now using ankerl::unordered_dense::map<std::string, RapidDataType> with a custom hash.
     // This allows us to store various types of data in the map, including strings, integers, doubles, and booleans.
-    // Why a custom hash and equality function?
-    // Because ankerl::unordered_dense::map does not support transparent hash and equality functions,
-    // and neither does clang's libc++.
+    // Why a custom hash?
+    // Because ankerl::unordered_dense::map does not support transparent hash "by default". You'd need to define a custom
+    // struct to enable heterogeneous lookup. More details here: https://github.com/martinus/unordered_dense/tree/main?tab=readme-ov-file#324-heterogeneous-overloads-using-is_transparent
 
 
 

--- a/src/include/RapidTypes.h
+++ b/src/include/RapidTypes.h
@@ -50,22 +50,25 @@ GO_AWAY using RapidCommandFn = RiRi::Error::RiRiResult<std::string_view>(*)(cons
  * The `is_transparent` type is used to indicate that this hash function can be used with both `std::string` and `std::string_view` keys.
  * This is important, as `is_transparent` is not explicitly defined in the `ankerl::unordered_dense library` :(
  * 
- * I maybe wrong about that, but it doesn't seem to work without this workaround.
+ * I maybe wrong about that, but it doesn't seem to work without this workaround (I was wrong)
  * 
+ *EDIT: `ankerl` does support it, just not by default (unlike `unordered_map`), to enable heterogeneous lookup, you'd need to define a `struct` like this.
  * 
  * @param s A `std::string` to hash.
  * @param sv A `std::string_view` to hash.
  * @return The hash value as a `size_t`.
  * @note This is used in the `MemoryMap` and `AuxCommandMap` to allow fast lookups using both `std::string` and `std::string_view` keys.
+ * @note For more details refer: https://github.com/martinus/unordered_dense/tree/main?tab=readme-ov-file#324-heterogeneous-overloads-using-is_transparent
  */
 GO_AWAY struct RapidHash {
     using is_transparent = void;
+    using is_avalanching = void; // mark class as high quality avalanching hash
 
-    size_t operator()(const std::string& s) const noexcept {
+    [[nodiscard]] size_t operator()(const std::string& s) const noexcept {
         return ankerl::unordered_dense::hash<std::string>{}(s);
     }
 
-    size_t operator()(std::string_view sv) const noexcept {
+    [[nodiscard]] size_t operator()(std::string_view sv) const noexcept {
         return ankerl::unordered_dense::hash<std::string_view>{}(sv);
     }
 };


### PR DESCRIPTION
Sigh..

- Fixed comments about `ankerl::unordered_dense` and heterogeneous lookup.
- Fixed `RapidHash`, it now follows the expected implementation.
- Added a warning in the `string_view` note, to notify the reader that the note is outdated and partially incorrect.