### PR TITLE
fix: amend include errors and add cmake implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # IDE files (for VS Code or other editors)
 .vscode/
+.idea/
 
 # MacOS system files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # CMake generated files
 /CMakeLists.txt.user
 /CMakeCache.txt
+/cmake-build-debug-clang
 /build/
 *.exe
 *.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.20)
+project(RiRiCore LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Force clang++ as the compiler
+set(CMAKE_CXX_COMPILER "clang++")
+
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -flto -march=native -fuse-ld=lld ")
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+add_executable(riri
+        src/cli/main.cpp
+        src/core/Commands.cpp
+        src/core/MemoryMaps.cpp
+        src/core/DataManager.cpp
+        # Add more .cpp files here as needed
+)
+
+# Define preprocessor macros
+target_compile_definitions(riri PRIVATE
+        RIRI_DEV_MODE
+        RIRI_BUILD_DLL
+)
+
+target_include_directories(riri PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/include
+        ${CMAKE_SOURCE_DIR}/src/utils
+        #${CMAKE_SOURCE_DIR}/include/riri/
+)
+
+target_compile_options(riri PRIVATE ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}})

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ or simply **RiRi** :)
 ![Made with C++](https://img.shields.io/badge/Made_with-C++23-green)
 ![Compiler](https://img.shields.io/badge/compiler-clang++-blueviolet)
 ![Build](https://img.shields.io/badge/build-pending-lightgrey)  
-[![License](https://img.shields.io/badge/license-RRDL_v1-informational)](./LICENSE)
+[![License](https://img.shields.io/badge/license-RRDL_v1-informational)](./License.md)
 ![Last Commit](https://img.shields.io/github/last-commit/ad4rsh2701/RiRi)
 ![Contributors](https://img.shields.io/github/contributors/ad4rsh2701/RiRi)
 

--- a/src/core/DataManager.cpp
+++ b/src/core/DataManager.cpp
@@ -1,4 +1,4 @@
-#include "src/include/DataManager.h"
+#include "../include/DataManager.h"
 
 using namespace RiRi;
 

--- a/src/include/DataManager.h
+++ b/src/include/DataManager.h
@@ -5,7 +5,7 @@
 
 #include "RapidTypes.h"
 #include "RiRiMacros.h"
-#include "src/include/MemoryMaps.h"
+#include "MemoryMaps.h"
 
 /**
  * @brief ### WARNING: INTERNAL ZONE

--- a/src/include/MemoryMaps.h
+++ b/src/include/MemoryMaps.h
@@ -3,9 +3,9 @@
 #include <variant>
 #include <string_view>
 
-#include "src/include/RapidTypes.h"
-#include "ankerl/unordered_dense.h"
-#include "src/include/RiRiMacros.h"
+#include "RapidTypes.h"
+#include "../core/ankerl/unordered_dense.h"
+#include "RiRiMacros.h"
 
 
 /**

--- a/src/include/RapidTypes.h
+++ b/src/include/RapidTypes.h
@@ -5,8 +5,8 @@
 #include <span>
 
 #include "RiRiMacros.h"
-#include "src/utils/RapidError.h"
-
+#include "../utils/RapidError.h"
+#include "../core/ankerl/unordered_dense.h"
 
 /**
  * @brief Represents a rapid data type that can hold various types of values.

--- a/src/utils/RapidError.h
+++ b/src/utils/RapidError.h
@@ -4,7 +4,7 @@
 #include <expected>   // C++23: Like Rust's Result<T, E>
 #include <utility>    // for std::forward
 
-#include "src/include/RiRiMacros.h"  // For GO_AWAY macro
+#include "../include/RiRiMacros.h"  // For GO_AWAY macro
 
 /**
  * @brief ## INTERNAL ERROR SYSTEM
@@ -41,7 +41,7 @@ namespace RiRi::Error {
      * This function returns a string_view representing the error message
      * associated with the specified RiRiError.
      */
-    GO_AWAY std::string_view get_error_message(RiRiError error) noexcept {
+    GO_AWAY inline std::string_view get_error_message(RiRiError error) noexcept {
         switch (error) {
             case RiRiError::Success:
                 return "Success";


### PR DESCRIPTION
### Added CMake Build configuration

Now one can build RiRi using CMake. However, do note that this is a very basic implementation, testing remains.

This resolves #10

### Include Errors
Switching to cmake and CLion made me realize just how many include errors RiRi has.
- All include errors has been patched up.

### Other fixes:
- Inlined `get_error_message()` in `RapidError.h`.