### PR TITLE
feat: (Ra)pid (Re)sponse (Sy)stem

### DIFF
--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <utility>
+#include <new>
+
+enum class StatusCode : std::uint8_t {
+    // Success codes (0-99)
+    OK = 0,
+    OK_WITH_ERRORS = 1,
+
+    // Client errors (100-199)
+    INVALID_ARGUMENT = 100,
+    NOT_FOUND = 101,
+    TYPE_ERROR = 102,
+    TOO_MANY_ERRORS = 103,
+
+    // Server errors (200+)
+    INTERNAL_ERROR = 200,
+    MULTI_FAILED = 201,
+};
+
+
+struct RapidResponse {
+    StatusCode response;
+
+    constexpr bool ok() const noexcept {
+        return response == StatusCode::OK;
+    }
+};
+
+struct RiRiResponseContainer {
+    static constexpr size_t INLINE_CAPACITY = 4;
+
+    StatusCode overall_code = StatusCode::OK;
+
+    alignas(std::pair<std::string_view, StatusCode>)
+    // weird looking syntax, but not actually weird
+    char inline_storage[INLINE_CAPACITY * sizeof(std::pair<std::string_view, StatusCode>)];
+
+    std::pair<std::string_view, StatusCode>* failures = nullptr;
+    std::uint8_t failure_count = 0;
+    std::uint8_t capacity = 0;
+
+    RiRiResponseContainer() noexcept {
+        // weird looking syntax and actually weird
+        failures = reinterpret_cast<std::pair<std::string_view, StatusCode>*>(inline_storage);
+        capacity = INLINE_CAPACITY;
+    }
+
+    void addFailure(std::string_view key, StatusCode code) {
+        if (failure_count >= capacity) {
+            overall_code = StatusCode::TOO_MANY_ERRORS;
+            return;
+        }
+        // weird looking syntax and actually not not weird?
+        new (&failures[failure_count]) std::pair{key, code};
+        ++failure_count;
+    }
+
+    void reset() {
+        failure_count = 0;
+        overall_code = StatusCode::OK;
+        // No destructors needed since we only hold trivially destructible types
+    }
+
+    // for iteration
+    auto begin() const noexcept { return failures; }
+    auto end()   const noexcept { return failures + failure_count; }
+};
+


### PR DESCRIPTION
### feat(RapidResponse): Replace std::expected/err with a dual-mode response system

Another day another struct? No, _two_ structs.

Resolves #17 (A better response + error system)

RiRi no longer relies on:
- ~~`std::unexpected`~~
- ~~`std::expected`~~
- ~~`std::string`~~

...to respond to the user, be it with a success code or an error code.

Introducing, the new over engineered response system for RiRi:

*Hmm... the name, let's see now, I have been abusing the word "Rapid" a lot so...*
*Rapid Response System (RaReSy)?*
### raresy!
How to _pronounce_ that? That's for you to figure it out.
(You should not expect much from the guy who named this repo "riri")

Anyways, moving to what **raresy** is:

- It's manages "how" RiRi responds to success/failures in the system.
- It's extremely light and is STL bloat free (the heavy ones).
- Header only

With **raresy** all success/failures have been represented via a `STATUS CODE`, which is an `enum` of type `int`.
- This allows for extensibility, we can add as many status codes as we want.
- This also allows us to mimic what HTTP does, for example, 0-100 for success codes, 100+ for client side error codes, 200+ for internal error codes (this needs refinement and a great taste in STATUS CODES, 404 for key not found!?).
- Any function facing the public API/end user, will return a STATUS CODE (not set in stone, maybe used internally).

"How does **raresy** return these `enums`?"

There are two methods:

1. Fast Response:
    - A simple struct-like-wrapper (called `RapidResponse` for now) is implemented over the `StatusCode` enum.
    - This struct is returned to the end user, it contains the `status` of type `StatusCode`.
    - It also contains a member function `bool ok()`, which allows the user to indirectly see whether there was a failure or not.
    - This will be used 90% of the time, for simple, fast, and clean responses.

2. Full Response:
    - I need to provide a context for this first.

---
Suppose, the use case of what `setCommand()` should return after being called.   
For 90% cases, it should return the `RapidResponse` struct, which contains one STATUS CODE enum, of 1 byte. So, in cases where only one Key-Value pair is passed to `setCommand()` and called, you can possibly get ONLY these three codes as a response using **Fast Response**:
- `OK`
- `INVALID_ARGS`
- `KEY_ALREADY_EXISTS`     

Which is more than enough, and covers all cases.

> **NOTE**
> - In RiRi, `SET` does not override existing keys, it only inserts UNIQUE keys (if key already exists -> it won't do it), this is planned.
> - I am ignoring errors from the parser in this example for simplicity.

Now, imagine that 10% use case, when you pass multiple key-value pairs to the `setCommand()`. Now using the **Fast Response** method, you will only get these four status codes:
- `OK`
- `OK_WITH_ERRORS`
- `ALL_KEYS_ALREADY_EXIST`
- `INVALID_ARGS`

Which.. gets the job done, until you do 1000 key-value pair inserts and RiRi responds with `OK_WITH_ERRORS`, good luck telling which keys were duplicate.

So, to give a more detailed response for specific cases like these which involve multiple key-value processes in a single command, **raresy** has "Full Response" method.
---

2. Full Response
   - This is a *very heavy* response, to be used only for diagnostics or if memory capacity isn't your bottleneck.
   - It returns an entire container (also a struct, named `RapidResponseConatainer`, for now), which consists of A LOT OF INFO.
   - What a full response looks like (of `setCommand()`):
    ```cpp
    Overall Status: OK_WITH_ERRORS
    key24: `KEY_ALREADY_EXISTS`
    key39: `KEY_ALREADY_EXISTS`

    // or
    Overall Status: OK
    ``` 
   - The implementation behind this is explained well enough in commit: 82d058b
   - Though, in general, we are creating an array of structs like:
     ```cpp
     [{your_key: StatusCode}, {your_key_1: StatusCode}, {...}, ...]
     ```
    - But only for the keys which caused an error during the insert. Basically, we are *tracking the errors* only.
    - Also, the number of errors tracked is configurable, but not dynamic, you must set it (when I make it configurable that is).
    - If the maximum number of errors have been tracked, and the `setCommand` internally encounters an error for more keys (even 1), you will get a message stating "`Max Error Tracking limit reached: There are more errors`", with overall status set as: `MULTI_ERRORS` instead of `OK_WITH_ERRORS`.
 
It's a very specific use case and pre mature benchmarking doesn't show any "significant" delay between the Fast Response and Full Response(slower by 2-3 nano seconds, sometimes equal/faster by 1-2 nanosecond, but I think all these is just noise). 

I have yet to benchmark for memory consumption, but it's pretty safe to assume that Full Response method will be taking more memory (way more memory), though I will still benchmark it for sanity reasons.

On a second thought, if memory is the only difference, then perhaps "LIGHT/HEAVY RESPONSE" would have been the apt name, oh and speaking of names.

All status code names, function names and struct names used above are provisional, they will be renamed. Additionally, the name "raresy" is not anything official, just a short name to be able to mention this system without typing "Rapid Response System" every time (I didn't like RRS as the acronym).

Do read #17 for more context and expect a notes under `.notes` real soon (as soon as I properly benchmark).