### PR TITLE
chore: remove the now outdated acronym of RiRi

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,12 +1,11 @@
 # RiRi Rapid Dev License (RRDL) v1.0  
-**© 2025 Adarsh Aryan (Shadow's Lure)**  
-Rapid In-Memory Redis Interface — RiRi
+**© 2025 Adarsh Aryan (Shadow's Lure)**
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software” or “RiRi”), to use, copy, modify, merge, and distribute the Software, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person getting a copy of this software and associated documentation files (the “Software” or “RiRi”), to use, copy, modify, merge, and distribute the Software, subject to the following conditions:
 
 -------------------------------------------------------------------------------
 ### 1. Attribution Requirements
-- You must retain this copyright notice and license in all copies or substantial portions of the Software.
+- You must retain this copyright notice and license in all copies or significant portions of the Software.
 - You must clearly credit the original author (“Adarsh Aryan”) and the project name “RiRi” in your project’s documentation, README file, or license/acknowledgments section.
 - Credit format should include: "Powered by RiRi by Adarsh Aryan" or equivalent clear attribution.
 - No attribution is required in user interfaces or end-user facing materials.
@@ -16,7 +15,6 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 
 - **Permitted**: Use RiRi as a component, dependency, or backend service in commercial or enterprise software.  
 - **Prohibited**: You may not sell, license, or distribute RiRi itself (or substantially similar versions) as a standalone commercial product or service.
-
 - Attribution is **required** in all cases of commercial use (see Section 1).
 
 Examples:
@@ -36,7 +34,7 @@ Examples:
 
 - You may **not** use “RiRi” or any confusingly similar to “RiRi” in your product, fork, or service name without written permission.
 - Including but not limited to `RiRi-[suffix]`, `[prefix]-RiRi`, `RiRiDB`, `RiRiX`.
-- You **may** use unrelated names like “MemoryCache”, “LiteStore”, etc.
+- You **may** use unrelated names like “MemoryCache,” “LiteStore,” etc.
 
 This restriction applies to project names, product branding, and marketing materials.
 
@@ -48,12 +46,12 @@ Contributors and users of this Software grant each other a perpetual, worldwide,
 -------------------------------------------------------------------------------
 ### 6. Liability Disclaimer
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED “AS IS,” WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -------------------------------------------------------------------------------
 
 **RiRi Rapid Dev License (RRDL) v1.0** : Fast paced quality development first, legality handled.
 
-For questions, permissions, or contributions, visit:  https://github.com/ad4rsh2701/RiRi
+For questions, permissions, or contributions, visit: https://github.com/ad4rsh2701/RiRi
 
 **Adarsh Aryan** a.k.a. **Shadow's Lure**, 2025

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Rapid In-Memory Redis Interface
-or simply **RiRi** :)
+# RiRi —A rapid, low-latency, in-memory key-value data engine
 
 ![Status](https://img.shields.io/badge/Status-PRE--MVP-red)
 ![Stage](https://img.shields.io/badge/stage-Under_Active_Development-darkorange)
@@ -11,7 +10,7 @@ or simply **RiRi** :)
 ![Last Commit](https://img.shields.io/github/last-commit/ad4rsh2701/RiRi)
 ![Contributors](https://img.shields.io/github/contributors/ad4rsh2701/RiRi)
 
-RiRi, or **Rapid In-Memory Redis Interface**, is a high-performance, multi-modal system for managing in-memory key-value data. It’s designed to be used as a lightweight C++ **library**, a drop-in **embedded** data engine, or a standalone **backend server** — depending on your use case.
+RiRi is a high-performance, multi-modal system for managing in-memory key-value data. It’s designed to be used as a lightweight C++ **library**, a drop-in **embedded** data engine, or a standalone **backend server** — depending on your use case.
 
 Built entirely from _scratch_ with performance and simplicity in mind, RiRi is crafted to be **fast**, **lightweight**, and **memory-efficient**. It leverages modern _C++23 features_ and relies on _one of the fastest hash maps available_ for its internal map structure.
 
@@ -32,26 +31,26 @@ In memory, abstractly speaking, the data is structured like this — think of it
 {
   "name": "RiRi",
   "complete": false,
-  "builds": 0,
+  "builds": 0
 }
 ```
 (Benefits of storing like this? — should be obvious, if not... _it’s a great little homework_)
 
 > Inside RiRi
 >- `keys` are of the type `std::string`.
->- `values` are of `RapidDataType` (via `std::variant` (C++23)), and currently supports boolean, integer, floating, string and character types.
+>- `values` are of `RapidDataType` (via `std::variant` (C++23)), and currently supports boolean, integer, floating, string, and character types.
 
-That's essentially what a key-value map or a ‘k-v map’ is. With this clarified, we can finally explain what RiRi is, in a much better way:
+That's what a key-value map or a ‘k-v map’ is. With this clarified, we can finally explain what RiRi is, in a much better way:
 
 - RiRi is a bunch of code compiled into a binary, which _at your mercy_ modifies the key-value map however you command (add, search, delete, etc.).
-- To achieve this, RiRi can be embedded directly into your code — acting as your own _temporary data holder/engine_. However with one difference... it's **extremely fast**.
+- To achieve this, RiRi can be embedded directly into your code — acting as your own _temporary data holder/engine_. However, with one difference... it's **extremely fast**.
 - Alternatively, RiRi can run as a standalone backend — in a traditional client-server setup. RiRi becomes the **server**, your program(s) the **client(s)**.
 
-The general idea of RiRi should be much clear now, as for the C++23 features and the _one of the fastest hash maps_; these are just tools, used to implement RiRi. These will be discussed in the upcoming sections with great detail (especially that map).
+The general idea of RiRi should be much clearer now, as for the C++23 features and the _one of the fastest hash maps_; these are just tools used to implement RiRi. These will be discussed in the upcoming sections with great detail (especially that map).
 
 Reiterating again, RiRi is made in **pure C++** and uses no external dependencies (except one, the hash map, which has no overhead, included with RiRi). Future scaling may involve python, node.js and java into RiRi (connector implementation).
 
-Oh and RiRi is made to be compiled in C++23 and above versions only. Why the latest C++ and not standard C++17? Because RiRi requires better and faster features, with minimal overhead, not standards.
+Oh, and RiRi is made to be compiled in C++23 and above versions only. Why the latest C++ and not standard C++17? Because RiRi requires better and faster features, with minimal overhead, which the latest C++ provides.
 
 ---
 This readme is incomplete


### PR DESCRIPTION
Resolves #20 

- Removed the acronym from README.md
- Removed the acronym from License.md

That should be it, I didn't find any other places where the acronym is still present.