### PR TITLE
feat: value-returning rapid response

### DIFF
--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -329,6 +329,25 @@ namespace RiRi::Response {
             new(&entries[entry_count]) std::pair{operation_target, entry};
             ++entry_count;
         }
+
+        /**
+         * @brief Adds a OPERATION_TARGET-VALUE pair to the Response's memory blob.
+         *
+         * @param operation_target : The target of an operation or an operation itself.
+         * @param entry : The value concerning the target.
+         */
+        void addValue(std::string_view operation_target, RapidDataType* entry) noexcept {
+            // We are going to update the OverallCode early, since this is the only error
+            // code this function can return.
+            OverallCode = StatusCode::ERR_SOME_OPERATIONS_FAILED;
+
+            // Is the overflow handled, if any? (if overflowed, start dynamic allocation)
+            if (handleOverflow()) return;
+
+            // Construct OPERATION_TARGET-VALUE in STORE at entry_count.
+            new(&entries[entry_count]) std::pair{operation_target, entry};
+            ++entry_count;
+        }
     };
 }
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -227,6 +227,14 @@ namespace RiRi::Response {
         }
 
         /**
+         * @brief Getter to return the overall status code
+         * @return _overall_code
+         */
+        constexpr StatusCode code() const noexcept {
+            return _overall_code;
+        }
+
+        /**
          * @brief Resets the RapidResponseFull state by clearing the failure count and
          * setting the overall status code to `StatusCode::OK`.
          */

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -28,7 +28,7 @@ static constexpr size_t VALUE_TRACKING_CAPACITY = 16;
 namespace RiRi::Response {
     /**
      * @brief Represents various status codes for responses within the RapidResponse framework.
-     *
+     *x
      * Status codes are categorized into multiple ranges based on their meanings:
      *
      * - SUCCESS CODES (0-99): Indicate successful operations.
@@ -140,9 +140,8 @@ namespace RiRi::Response {
      *
      *  Made with agony for the 10% use cases :D
      */
-    struct RapidResponseFull {
-        /// The overall status code defaulted to OK; if it stays OK, you are fine (probably).
-        StatusCode OverallCode = StatusCode::OK;
+    class RapidResponseFull {
+    public:
 
         // "No silly names yet?", Hey! I am trying to implement good coding habits okay
         // It's called self-explainable code, don't laugh... or ykw, here, a doc-string too, just in case
@@ -161,6 +160,18 @@ namespace RiRi::Response {
          */
         using ErrorEntryType = std::pair<std::string_view, StatusCode>;
 
+        RapidResponseFull() noexcept {
+            // Pointer now points to the ERROR_STORE and will move by `ErrorEntryType`
+            failures = reinterpret_cast<ErrorEntryType*>(ERROR_STORE);
+            // "Good Programming Principles," they said, "it will be less repetitive," they said.
+            capacity = TRACKING_CAPACITY;
+        }
+
+
+    private:
+
+        /// The overall status code defaulted to OK; if it stays OK, you are fine (probably).
+        StatusCode OverallCode = StatusCode::OK;
 
         /// A fixed blob or block of memory, which stores `ErrorEntryType` objects.
         alignas(ErrorEntryType)
@@ -171,23 +182,6 @@ namespace RiRi::Response {
 
         std::uint8_t failure_count = 0;
         std::uint8_t capacity = 0;
-
-        RapidResponseFull() noexcept {
-            // Pointer now points to the ERROR_STORE and will move by `ErrorEntryType`
-            failures = reinterpret_cast<ErrorEntryType*>(ERROR_STORE);
-            // "Good Programming Principles," they said, "it will be less repetitive," they said.
-            capacity = TRACKING_CAPACITY;
-        }
-
-        /**
-         * @brief Checks whether the overall status code is `StatusCode::OK`.
-         * @return True if the overall status code is `StatusCode::OK`, otherwise false.
-         */
-        constexpr bool ok() const noexcept {
-            return OverallCode == StatusCode::OK;
-        }
-
-
         /**
          * @brief Checks if the number of failures has exceeded the specified capacity and modifies the `OverallCode`
          * to `ERR_MULTIPLE_OPERATIONS_FAILED` if needed.
@@ -201,9 +195,8 @@ namespace RiRi::Response {
             return false;
         }
 
-
+    public:
         // At this point, everything should be very self-explainable.
-
         /**
          * @brief Adds a OPERATION_TARGET-STATUS_CODE pair to the Response's memory blob,
          * only if there is no overflow.
@@ -223,6 +216,14 @@ namespace RiRi::Response {
             OverallCode = StatusCode::ERR_SOME_OPERATIONS_FAILED;
 
             ++failure_count;
+        }
+
+        /**
+         * @brief Checks whether the overall status code is `StatusCode::OK`.
+         * @return True if the overall status code is `StatusCode::OK`, otherwise false.
+         */
+        constexpr bool ok() const noexcept {
+            return OverallCode == StatusCode::OK;
         }
 
         /**
@@ -250,6 +251,7 @@ namespace RiRi::Response {
 
         // you're welcome for the iterators.
     };
+
 
     /**
      * @brief Represents a value-returning response structure to track individual values and error
@@ -339,7 +341,7 @@ namespace RiRi::Response {
             // Is the overflow handled, if any? (if overflowed, start dynamic allocation)
             if (handleOverflow()) return;
 
-            // Construct OPERATION_TARGET-VALUE in STORE at entry_count.
+            // Construct OPERATION_TARGET-VALUE in STORE at entry_count.5
             new(&entries[entry_count]) std::pair{operation_target, entry};
             ++entry_count;
         }

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -323,13 +323,6 @@ namespace RiRi::Response {
             return false;
         }
 
-        // TODO: INSTEAD OF ONE FUNCTION, make it TWO functions addValue, addFailure/addStatus (CPU will love you)
-        // PLACEHOLDER function
-        void add(std::string_view operation_target, std::variant<RapidDataType*, StatusCode> entry) noexcept {
-            new(&entries[entry_count]) std::pair{operation_target, entry};
-            ++entry_count;
-        }
-
         /**
          * @brief Adds a OPERATION_TARGET-VALUE pair to the Response's memory blob.
          *

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -28,7 +28,7 @@ static constexpr size_t VALUE_TRACKING_CAPACITY = 16;
 namespace RiRi::Response {
     /**
      * @brief Represents various status codes for responses within the RapidResponse framework.
-     *x
+     *
      * Status codes are categorized into multiple ranges based on their meanings:
      *
      * - SUCCESS CODES (0-99): Indicate successful operations.
@@ -286,9 +286,9 @@ namespace RiRi::Response {
         /// Either `Value` or `StatusCode` will be returned per fetch request
         using ValueOrStatus = std::variant<RapidDataType*, StatusCode>;
 
-        RapidResponseValue() noexcept: capacity(VALUE_TRACKING_CAPACITY) {
+        RapidResponseValue() noexcept: _capacity(VALUE_TRACKING_CAPACITY) {
             // Pointer now points to the ERROR_STORE and will move by `ErrorEntryType`
-            entries = reinterpret_cast<EntryType *>(STORE);
+            _entries = reinterpret_cast<EntryType *>(_store);
             // *insert shrug here*
         }
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -336,8 +336,7 @@ namespace RiRi::Response {
          * @note This operation is noexcept and assumes that `EntryType` is trivially copyable.
          */
         void dynamically_grow() noexcept {
-
-            // HOW TO: ns to μs
+            // Increases capacity dynamically (RIP ns performance, hello μs)
 
             // Increasing the capacity by 1.5x (new buffer RAHH)
             const std::uint32_t new_capacity = _capacity + _capacity / 2 + 8; // The +8 helps for small initial sizes
@@ -393,7 +392,7 @@ namespace RiRi::Response {
                 dynamically_grow();
             }
 
-            // Construct OPERATION_TARGET-VALUE in STORE at entry_count.5
+            // Construct OPERATION_TARGET-VALUE in STORE at entry_count.
             new(&_entries[_entry_count]) EntryType{operation_target, entry};
             ++_entry_count;
         }

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -348,6 +348,23 @@ namespace RiRi::Response {
             new(&entries[entry_count]) std::pair{operation_target, entry};
             ++entry_count;
         }
+
+        /**
+         * @brief Adds a OPERATION_TARGET-STATUS_CODE pair to the Response's memory blob.
+         * @param operation_target : The target of an operation or an operation itself
+         * @param status_code : The value concerning the target
+         */
+        void addStatus(std::string_view operation_target, StatusCode status_code) noexcept {
+            // shrugieeee
+            OverallCode = StatusCode::ERR_SOME_OPERATIONS_FAILED;
+
+            // Is the overflow handled, if any? (if overflowed, start dynamic allocation)
+            if (handleOverflow()) return;
+
+            // Construct OPERATION_TARGET-STATUS_CODE in STORE at entry_count.
+            new(&entries[entry_count]) std::pair{operation_target, status_code};
+            ++entry_count;
+        }
     };
 }
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -332,7 +332,9 @@ namespace RiRi::Response {
         void addValue(std::string_view operation_target, RapidDataType* entry) noexcept {
             // We are going to update the OverallCode early, since this is the only error
             // code this function can return.
-            OverallCode = StatusCode::ERR_SOME_OPERATIONS_FAILED;
+            // Update: We don't need to update the status code at all. This is the "OK" case,
+            // which is the default status code.
+            // OverallCode = StatusCode::ERR_SOME_OPERATIONS_FAILED;
 
             // Is the overflow handled, if any? (if overflowed, start dynamic allocation)
             if (handleOverflow()) return;

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -359,6 +359,15 @@ namespace RiRi::Response {
         }
 
     public:
+
+        /**
+         * @brief Getter to return the overall status code
+         * @return _overall_code
+         */
+        constexpr StatusCode code() const noexcept {
+            return _overall_code;
+        }
+
         /**
          * @brief Checks whether the overall status code is `StatusCode::OK`.
          * @return True if the overall status code is `StatusCode::OK`, otherwise false.
@@ -406,6 +415,19 @@ namespace RiRi::Response {
             new(&_entries[_entry_count]) EntryType{operation_target, status_code};
             ++_entry_count;
         }
+
+        /**
+        * @brief Provides a constant iterator pointing to the beginning of the `entries` collection.
+        * @return A pointer to the first error entry in the `entries` collection.
+        */
+        constexpr auto begin() const noexcept { return _entries; }
+
+        /**
+         * @brief Provides a constant iterator pointing to the end of the `entries` collection.
+         * @return A pointer to one past the last error entry in the `entries` collection.
+         */
+        constexpr auto end() const noexcept { return _entries + _entry_count; }
+
     };
 }
 


### PR DESCRIPTION
Resolves #19 

## Value-Returning Rapid Response: `class RapidResponseValue`

FINALLY

Added a new class `RapidResponseValue`, this class provides creation of responses in the following manner:
```cpp
{
    key1: value1,
    key2: ERR_KEY_NOT_FOUND,
    key3: value3,
    key4: value4
}
```
Saw something new? Now RaReSy (RiRi's response system) can respond with VALUES too!! 

---
### Context

Previously the two structs: `RapidResponse` and `RapidResponseFull` (now class), only handled status codes and key-status code pairs respectively.

Suppose you tried setting to keys: `key1`(duplicate) and `key2`(unique)
So you'll get the following response (`RapidResponse`):
```cpp
// set key1 v1
{ ERR_KEY_ALREADY_EXISTS }

// set key2 v2
{ OK }
```
or you'll get (`RapidResponseFull`):
```cpp
// set key1 v1 key2 v2
{ {overall_code: ERR_SOME_OPERATIONS_FAILED},
    {
        key1: ERR_KEY_ALREADY_EXISTS,
    }
} // in one whole response
// absence of key2, implies the operation was successful, this is a list of "failure" not success.
```
But values were never returned, this made value-returning functions like `GET`, `GET_ALL`, etc. impossible to implement.

---

This PR resolves that by introducing a class, `RapidResponseValue`.

The structure of the class:

```cpp
class RapidResponseValue{
    public:
        // Either `Value` or `StatusCode` will be returned per fetch request
        using ValueOrStatus = std::variant<RapidDataType*, StatusCode>;

        using EntryType = std::pair<std::string_view, ValueOrStatus>;

        // This is important, trust for now.
        static_assert(std::is_trivially_copyable_v<EntryType>,
          "EntryType must be trivially copyable!!! Don't Forget!");
       
        // Constructor (more to be added)
        constexpr RapidResponseValue() noexcept { ... }
        
    private:
        StatusCode _overall_code = StatusCode::OK;
        
        // Standard static-allocation, like we did in RapidResponseFull
        alignas(EntryType)
        std::byte _static_store[...]{};
        std::unique_ptr<EntryType[]> _dynamic_store = nullptr;
        ...

       // secret sauce (revealed later)
        void dynamically_grow() noexcept { ... }
        
    public:
        constexpr  StatusCode code() const noexcept { .... }
        constexpr bool ok() const noexcept { .... }
        void addValue( ... ) noexcept {
            ...
            dynamically_grow();
        }
        void addStatus( ... ) noexcept {
            ...
            dynamically_grow();
        }
        
        // iterators
        constexpr auto begin() const noexcept { ... }
        constexpr auto end() const noexcept { ... }
}
```

### What's different from `RapidResponseFull`?

#### 1. `addFailure` split into `addStatus` and `addValue`:
The biggest difference is that `RapidResponseFull` was an error-reporting only container, it never reported success (it didn't need to, since it was redundant). `RapisResponseValue` on the other hand needs to report the errors *and the success* reports too, since in some success cases, there might be values attached, without which the response is meaningless.
- `addStatus` adds a `key`-`StatusCode` pair to the response buffer
- `addValue` adds a `key`-`value` pair to the response buffer

#### 2. `dynamically_grow()` function:
- In `RapidResponseFull`, there was a fixed limit on how many errors will be reported, hence a static buffer of fixed size was assigned, dynamic allocation was never needed.
- In `RapidResponseValue`, one cannot determine the size of the response (key-value or status-value) and the number of responses is entirely dependent on the input command (the number of keys to fetch in a bulk `GET` command). Hence, this time, we need to dynamically allocate some memory as to NOT drop any responses (since both the error and success responses are valuable).

To start off however, we allocate a static buffer anyways so the smaller commands be responded quickly.

When the static buffer is full, the `dynamically_grow()` function is called, which:
- Creates a heap buffer of larger size than the static buffer (by a factor of 1.5x + 8)
- Copies all the entries (both from static or previous heap buffer) to the new buffer using `memcpy`
- Resolves the pointers to now point at the new buffer

Structure of the function:

```cpp
        void dynamically_grow() noexcept {
            const std::uint32_t new_capacity = _capacity + _capacity / 2 + 8; 
            auto new_dynamic_store = std::make_unique<EntryType[]>(new_capacity);
            std::memcpy(...);
            _dynamic_store = std::move(new_dynamic_store);
            ...
        }
```

NOTE: Notice the carefree use of `memcpy`, this is done only because we know that `EntryType` is trivially copyable (statically asserted that too).

The functions (`addValue` and `addStatus`) work with the pointers to the buffers and not the buffers themselves, so `dynamically_grow()` need only handle the expansion of the buffer and not the construction of the objects.
