### PR TITLE
refactor: `RapidResponse` goes class

### DIFF
--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -95,10 +95,12 @@ namespace RiRi::Response {
 
 
     /**
-     * @brief Represents a response structure within the RapidResponse framework.
+     * @brief Represents a response class within the RapidResponse framework.
      *
-     * The `RapidResponse` struct encapsulates the response status and
+     * The `RapidResponse` class encapsulates the response status and
      * provides helper functions within it to evaluate the `StatusCode` state.
+     *
+     * It also provides a getter function to retrieve the response status.
      *
      * This only holds the overall status code; even in cases where multiple
      * status codes might be required, in such cases, an appropriate status
@@ -110,8 +112,11 @@ namespace RiRi::Response {
     class RapidResponse {
 
     public:
-        // Default constructor initializes response to the most common case.
+        // Default constructor initializes `response` to the most common case.
         RapidResponse() noexcept : response(StatusCode::OK) {}
+
+        // Explicit constructor to initialize `response` with StatusCode types.
+        explicit RapidResponse(StatusCode status_code) noexcept : response(status_code) {}
 
     private:
         /// Represents a single status outcome — either from a single operation

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -107,13 +107,26 @@ namespace RiRi::Response {
      * Though let's be honest, you will still most likely use this, 90% of the time.
      *
      */
-    struct RapidResponse {
+    class RapidResponse {
+
+    public:
+        // Default constructor initializes response to the most common case.
+        RapidResponse() noexcept : response(StatusCode::OK) {}
+
+    private:
         /// Represents a single status outcome — either from a single operation
         /// or an overall result when no per-operation diagnostics are needed.
         StatusCode response;
 
+    public:
+        /**
+         * @brief Returns the response of the container
+         * @return StatusCode
+         */
+        constexpr StatusCode code() const noexcept {
+            return response;
+        }
 
-        // should be obvious but-
         /**
          * @brief Checks if the response status is successful.
          * @return `true` if the response status is `StatusCode::OK`, otherwise false.


### PR DESCRIPTION
Resolves #23 

Changes made:
- `RapidResponse`: `struct` to `class`
- Added a default and explicit constructors (initializing `StatusCode response`)
- Added a `code()` method as a getter for `StatusCode response`
- Updated docstrings and comments to reflect the new changes