### PR TITLE
feat: lighter value returning response

### DIFF
--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -45,7 +45,8 @@ namespace RiRi::Response {
             // Will add more as I see fit.
 
         // INFO CODES (100-199)
-            // Nothing here, for now.
+        ORPHANED = 100,                         // Default uninitialized state (equivalent to UNSET in other similar systems).
+            // Basically, the response is currently empty and pending assignment.
 
         // WARNING CODES (200-299)
         WARN_KEY_STORE_NEARING_CAPACITY = 200,  // COMMAND LEVEL
@@ -160,7 +161,7 @@ namespace RiRi::Response {
      * Made with agony for the 10% use cases :D
      *
      * @note Success cases are not tracked, and the absence of keys in the response means the set was successful
-     * unless the overall code is `ERR_MULTIPLE_OPERATIONS_FAILED`, in which case... good luck I guess(you bought
+     * unless the overall code is `ERR_MULTIPLE_OPERATIONS_FAILED`, in which case... good luck I guess (you bought
      * this on yourself honestly).
      *
      * @note The tracking capacity is manually set; by default, set to 8. This means only 8 errors will be

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <memory>
 #include <new>
+#include <concepts>
 
 #include <RapidTypes.h>
 
@@ -308,6 +309,35 @@ namespace RiRi::Response {
         }
 
         // you're welcome for the iterators.
+    };
+
+
+    /**
+     * @brief A single-status-value response class
+     * This class encapsulates the response status code and a RapidDataType object (value).
+     * @note This class does not own memory
+     */
+    class RapidResponseOneValue {
+
+        const RapidDataType* _value = nullptr;
+        StatusCode _status_code = StatusCode::ORPHANED;
+
+    public:
+
+        [[nodiscard]] StatusCode code() const noexcept { return _status_code; }
+
+        [[nodiscard]] bool ok() const noexcept { return _status_code == StatusCode::OK; }
+
+        [[nodiscard]] const RapidDataType* value () const noexcept { return _value; }
+
+        void fill(const RapidDataType* value, const StatusCode code) noexcept {
+            _value = value;
+            _status_code = code;
+        }
+
+        void setValue(const RapidDataType* ptr) noexcept { _value = ptr; }
+
+        void setCode(const StatusCode code) noexcept { _status_code = code; }
     };
 
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -13,7 +13,7 @@
 static constexpr size_t TRACKING_CAPACITY = 8;
 
 /// This constant defines the number of ValueOrStatus entries to be tracked
-static constexpr size_t VALUE_TRACKING_CAPACITY = 16;
+static constexpr size_t VALUE_TRACKING_CAPACITY = 8;
 
 /**
  * @brief RiRi's custom response system

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -133,7 +133,7 @@ namespace RiRi::Response {
          * @brief Returns the response of the container
          * @return StatusCode
          */
-        constexpr StatusCode code() const noexcept {
+        [[nodiscard]] constexpr StatusCode code() const noexcept {
             return response;
         }
 
@@ -141,7 +141,7 @@ namespace RiRi::Response {
          * @brief Checks if the response status is successful.
          * @return `true` if the response status is `StatusCode::OK`, otherwise false.
          */
-        constexpr bool ok() const noexcept {
+        [[nodiscard]] constexpr bool ok() const noexcept {
             return response == StatusCode::OK;
         }
     };
@@ -160,8 +160,8 @@ namespace RiRi::Response {
      * Made with agony for the 10% use cases :D
      *
      * @note Success cases are not tracked, and the absence of keys in the response means the set was successful
-     * unless the overall code is `ERR_MULTIPLE_OPERATIONS_FAILED`, in which case... good luck ig (you bought this
-     * on yourself honestly).
+     * unless the overall code is `ERR_MULTIPLE_OPERATIONS_FAILED`, in which case... good luck I guess(you bought
+     * this on yourself honestly).
      *
      * @note The tracking capacity is manually set; by default, set to 8. This means only 8 errors will be
      * reported. If there are more errors than the tracking capacity, the overall status code becomes
@@ -260,7 +260,7 @@ namespace RiRi::Response {
          * @brief Checks whether the overall status code is `StatusCode::OK`.
          * @return True if the overall status code is `StatusCode::OK`, otherwise false.
          */
-        constexpr bool ok() const noexcept {
+        [[nodiscard]] constexpr bool ok() const noexcept {
             return _overall_code == StatusCode::OK;
         }
 
@@ -268,7 +268,7 @@ namespace RiRi::Response {
          * @brief Getter to return the overall status code
          * @return _overall_code
          */
-        constexpr StatusCode code() const noexcept {
+        [[nodiscard]] constexpr StatusCode code() const noexcept {
             return _overall_code;
         }
 
@@ -276,7 +276,7 @@ namespace RiRi::Response {
          * @brief Getter to return the total number of failures
          * @return _failure_count
          */
-        constexpr std::uint32_t totalFailures() const noexcept {
+        [[nodiscard]] constexpr std::uint32_t totalFailures() const noexcept {
             return _failure_count;
         }
 
@@ -295,14 +295,14 @@ namespace RiRi::Response {
          * @brief Provides a constant iterator pointing to the beginning of the `failures` collection.
          * @return A pointer to the first error entry in the failure collection.
          */
-        constexpr auto begin() const noexcept { return _failures; }
+        [[nodiscard]] constexpr auto begin() const noexcept { return _failures; }
 
         /**
          * @brief Provides a constant iterator pointing to the end of the `failures` collection.
          * @return A pointer to one past the last error entry in the failure collection.
          */
-        constexpr auto end() const noexcept {
-            // only iterate upto the capacity or failure count; whichever is lower
+        [[nodiscard]] constexpr auto end() const noexcept {
+            // only iterate up to the capacity or failure count; whichever is lower
             return _failures + (_failure_count > _capacity ? _capacity : _failure_count);
         }
 
@@ -346,9 +346,11 @@ namespace RiRi::Response {
          */
         using EntryType = std::pair<std::string_view, ValueOrStatus>;
 
-        // Just in case my future self decides to make the EntryType trivially non-destructible.
+        // Just in case my future self decides to make the EntryType trivially non-destructible/copyable.
         static_assert(std::is_trivially_destructible_v<EntryType>,
-          "EntryType must be trivially destructible!!! Don't Forget!");
+          "EntryType must be trivially destructible!!!");
+        static_assert(std::is_trivially_copyable_v<EntryType>,
+          "EntryType must be trivially copyable!!!");
         // A little reminder for him when his code doesn't compile.
 
         constexpr RapidResponseValue() noexcept
@@ -392,7 +394,7 @@ namespace RiRi::Response {
             // Allocate a new heap buffer of the new capacity.
             auto new_dynamic_store = std::make_unique<EntryType[]>(new_capacity);
 
-            // Copy elements from old buffer to new buffer (safe to do so; EntryType is trivially copyable)
+            // Copy elements from the old buffer to the new buffer (safe to do so; EntryType is trivially copyable)
             std::memcpy(new_dynamic_store.get(), _entries, _entry_count * sizeof(EntryType));
             // Using `memcpy` for now (trivially copyable types only, enforced by static_assert above).
             // Will switch to `std::uninitialized_move` if EntryType becomes non-trivial in the future.
@@ -413,7 +415,7 @@ namespace RiRi::Response {
          * @brief Getter to return the overall status code
          * @return _overall_code
          */
-        constexpr StatusCode code() const noexcept {
+        [[nodiscard]] constexpr StatusCode code() const noexcept {
             return _overall_code;
         }
 
@@ -421,7 +423,7 @@ namespace RiRi::Response {
          * @brief Checks whether the overall status code is `StatusCode::OK`.
          * @return True if the overall status code is `StatusCode::OK`, otherwise false.
          */
-        constexpr bool ok() const noexcept {
+        [[nodiscard]] constexpr bool ok() const noexcept {
             return _overall_code == StatusCode::OK;
         }
 
@@ -469,13 +471,13 @@ namespace RiRi::Response {
         * @brief Provides a constant iterator pointing to the beginning of the `entries` collection.
         * @return A pointer to the first error entry in the `entries` collection.
         */
-        constexpr auto begin() const noexcept { return _entries; }
+        [[nodiscard]] constexpr auto begin() const noexcept { return _entries; }
 
         /**
          * @brief Provides a constant iterator pointing to the end of the `entries` collection.
          * @return A pointer to one past the last error entry in the `entries` collection.
          */
-        constexpr auto end() const noexcept { return _entries + _entry_count; }
+        [[nodiscard]] constexpr auto end() const noexcept { return _entries + _entry_count; }
 
     };
 }


### PR DESCRIPTION
Resolves #27 

Changes made:
* [Added `[[nodiscard]]` to methods and updated `static_assert` for `EntryType`](https://github.com/ad4rsh2701/RiRi/commit/e8ea38d3a9d57b854ead9564f785d8bd58d14f8a)


* [Added `ORPHANED` status code](https://github.com/ad4rsh2701/RiRi/commit/c06fde1f2b1c0036e4884edf7b5db24ff777d395)

* [Added `RapidResponseOneValue` class](https://github.com/ad4rsh2701/RiRi/commit/9853efe0a77b2828fd2d5d0596fd754f401e7368)

* [Updated `VALUE_TRACKING_CAPACITY` to 8](https://github.com/ad4rsh2701/RiRi/commit/556786c7f2e10a67a48783d729ea76d753c6aad5)

Didn't rename all the classes or added docs for the new class because everything will be refactored anyways because of #28.