### PR TITLE
refactor: Generalize RaReSy classes via concepts/templates, add OOM memory guardrails and automated status escalation

### DIFF
--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -253,7 +253,7 @@ namespace RiRi::Response {
             // A very neat use of `new`
             // Basically, we are "constructing" the pair at the `failures` position (`failure_count`).
             // Oh and yes, the memory is properly aligned and pre-allocated.
-            new(&_failures[_failure_count]) ErrorEntryType{field_target, error_code};
+            new(&_failures[_failure_count-1]) ErrorEntryType{field_target, error_code};
 
             // And update the OverallCode to ERR_SOME_OPERATIONS_FAILED (406) as well.
             _overall_code = StatusCode::ERR_SOME_OPERATIONS_FAILED;

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -484,30 +484,42 @@ namespace RiRi::Response {
          * This method allocates a new buffer of larger size (by a factor of 1.5x) while copying the previous
          * existing elements of the older buffer.
          *
+         * @return True if the growth was successful, else false (in the case of OOM)
+         *
          * @note This operation is noexcept and assumes that `EntryType` is trivially copyable.
          */
-        void dynamically_grow() noexcept {
+        [[nodiscard]] bool dynamically_grow() noexcept {
             // Increases capacity dynamically (RIP ns performance, hello μs)
 
             // Increasing the capacity by 1.5x (new buffer RAHH)
             const std::uint32_t new_capacity = _capacity + _capacity / 2 + 8; // The +8 helps for small initial sizes
 
-            // Allocate a new heap buffer of the new capacity.
-            auto new_dynamic_store = std::make_unique<EntryType[]>(new_capacity);
+            // pointer to new dynamic store
+            std::unique_ptr<EntryType[]> new_dynamic_store;
 
+            // TRY to allocate a new heap buffer of the new capacity.
+            try {
+                new_dynamic_store = std::make_unique<EntryType[]>(new_capacity);
+            } catch (const std::bad_alloc&) {
+                // return false in case of Out of Memory (OOM)
+                return false;
+            }
             // Copy elements from the old buffer to the new buffer (safe to do so; EntryType is trivially copyable)
             std::memcpy(new_dynamic_store.get(), _entries, _entry_count * sizeof(EntryType));
-            // Using `memcpy` for now (trivially copyable types only, enforced by static_assert above).
+            // Using `memcpy` for now.
             // Will switch to `std::uninitialized_move` if EntryType becomes non-trivial in the future.
 
             // We move the new buffer into our class's ownership.
             _dynamic_store = std::move(new_dynamic_store);
-            // If we were previously on the heap, the old _heap_store's
+            // If we were previously on the heap, the old dynamic_store's
             // destructor is called automatically when we re-assign it,
             // freeing the old memory; perks of unique_ptr
 
             _entries = _dynamic_store.get();   // Point to the new buffer
             _capacity = new_capacity;          // Update capacity
+
+            // no bad alloc
+            return true;
         }
 
         /**
@@ -587,8 +599,14 @@ namespace RiRi::Response {
             // which is the default status code.
             // OverallCode = StatusCode::ERR_SOME_OPERATIONS_FAILED;
 
+            // if OOM, we bail
+            if (_overall_code == StatusCode::ERR_OUT_OF_MEMORY) return;
+
             if (_entry_count >= _capacity) {
-                dynamically_grow();
+                if (!dynamically_grow()) {
+                    _overall_code = StatusCode::ERR_OUT_OF_MEMORY;
+                    return;
+                }
             }
 
             // Construct OPERATION_TARGET-VALUE in STORE at entry_count.
@@ -608,8 +626,14 @@ namespace RiRi::Response {
         void addStatusEntry(F1 target_field, StatusCode status_code) noexcept {
             // shrugieeee
 
+            // if OOM, we bail
+            if (_overall_code == StatusCode::ERR_OUT_OF_MEMORY) return;
+
             if (_entry_count >= _capacity) {
-                dynamically_grow();
+                if (!dynamically_grow()) {
+                    _overall_code = StatusCode::ERR_OUT_OF_MEMORY;
+                    return;
+                };
             }
 
             // Construct OPERATION_TARGET-STATUS_CODE in STORE at entry_count.

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -143,16 +143,13 @@ namespace RiRi::Response {
     class Status {
 
     public:
-        // The default constructor initializes `_status_code` to the most common case.
-        Status() noexcept : _status_code(StatusCode::OK) {}
-
         // Explicit constructor to initialize `_status_code` with StatusCode types.
         explicit Status(StatusCode status_code) noexcept : _status_code(status_code) {}
 
     private:
         /// Represents a single status outcome — either from a single operation
         /// or an overall result when no per-operation diagnostics are needed.
-        StatusCode _status_code;
+        StatusCode _status_code = StatusCode::ORPHANED;
 
     public:
         /**
@@ -580,7 +577,7 @@ namespace RiRi::Response {
     private:
 
         /// The overall status code defaulted to OK; if it stays OK, you are fine (probably).
-        StatusCode _overall_code = StatusCode::OK;
+        StatusCode _overall_code = StatusCode::OK; // cannot be ORPHANED, we have no fn for success cases
 
         /// A fixed blob or block of memory, which stores `ErrorEntryType` objects.
         alignas(ErrorEntryType)

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -283,6 +283,10 @@ namespace RiRi::Response {
         static_assert(std::is_trivially_copyable_v<EntryType>, "EntryType must be trivially copyable!!!");
         // A little reminder for him when his code doesn't compile.
 
+        // Well, since we will be dealing with constructors, we need
+        // to manually define a default constructor too
+        constexpr StatusBatchWith() noexcept = default;
+
         // Delete copy constructors
         StatusBatchWith(const StatusBatchWith&) = delete;
         StatusBatchWith& operator=(const StatusBatchWith&) = delete;
@@ -558,6 +562,9 @@ namespace RiRi::Response {
         using ErrorEntryType = std::pair<F, StatusCode>;
         static_assert(std::is_trivially_destructible_v<ErrorEntryType>, "EntryType must be trivially destructible!!!");
         // Must be trivially destructible
+
+        // default constructor
+        constexpr StatusErrorBatchWith() noexcept = default;
 
         // Delete the copy constructors
         StatusErrorBatchWith(const StatusErrorBatchWith&) = delete;

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -481,13 +481,9 @@ namespace RiRi::Response {
          * @return StatusCode
          */
         [[nodiscard]] static constexpr StatusCode determine_general_code(const StatusCode status_code) noexcept {
-            if (isSuccess(status_code) || isInfo(status_code)) {
-                return StatusCode::OK;
-            }
-            if (isWarning(status_code)) {
-                return StatusCode::WARN_RESPONSE_CONTAINS_WARNINGS;
-            }
-            // If it's not success, info, or warning, it must be an error
+            const auto val = static_cast<std::uint16_t>(status_code);
+            if (val < 200) return StatusCode::OK;         // success + info
+            if (val < 400) return StatusCode::WARN_RESPONSE_CONTAINS_WARNINGS;
             return StatusCode::ERR_SOME_OPERATIONS_FAILED;
         }
 
@@ -497,16 +493,20 @@ namespace RiRi::Response {
          */
         constexpr void escalate_overall_code(const StatusCode status_code) noexcept {
 
-            // A tiny branch for cases like OK getting passed
-            // eh never mind, replacing a full register is faster than branching
-            // No wait, we need this, so that it doesn't go to that weird branch
-            // which computes general_code and stuff, not needed for same codes
-            if (_overall_code == status_code) { return; }
-
             // 0. nuke case, do nothing since nothing can escalate this
             if (_overall_code == StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED) { return; }
 
             const StatusCode general_code = determine_general_code(status_code);
+
+            // A tiny branch for cases like OK getting passed
+            // eh never mind, replacing a full register is faster than branching
+            // No wait, we need this, so that it doesn't go to other heavier branches
+            // if (_overall_code == general_code) { return; }
+            // actually really nvm two branches is better anyway, and since
+            // one of the branches is just checking overall code, the compiler
+            // will never branch wrong with just two cases, the second branch isn't
+            // that heavy, and for same general codes, it never even executes into
+            // that branch anyway. <- What being at the office does to a guy
 
             // 1. If ORPHANED, just set
             if (_overall_code == StatusCode::ORPHANED) {

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -232,12 +232,9 @@ namespace RiRi::Response {
         static_assert(std::is_trivially_destructible_v<ErrorEntryType>, "EntryType must be trivially destructible!!!");
         // Must be trivially destructible
 
-        constexpr StatusErrorBatchWith() noexcept {
-            // Pointer now points to the ERROR_STORE and will move by `ErrorEntryType`
-            _failures = reinterpret_cast<ErrorEntryType*>(_error_store);
-            // "Good Programming Principles," they said, "it will be less repetitive," they said.
-            _capacity = TRACKING_CAPACITY;
-        }
+        // Delete the copy constructors
+        StatusErrorBatchWith(const StatusErrorBatchWith&) = delete;
+        StatusErrorBatchWith& operator=(const StatusErrorBatchWith&) = delete;
 
 
     private:
@@ -252,8 +249,9 @@ namespace RiRi::Response {
         /// Pointer that will track error entries, initialized in constructor to point to ERROR_STORE
         ErrorEntryType *_failures = nullptr;     // Aptly named
 
-        std::uint32_t _failure_count = 0;
-        std::uint8_t _capacity = 0;
+        // Pointer points to the ERROR_STORE and will move by `ErrorEntryType`
+        std::uint32_t _failure_count = reinterpret_cast<ErrorEntryType*>(_error_store);
+        std::uint8_t _capacity = TRACKING_CAPACITY;
 
         /**
          * @brief Checks if the number of failures has exceeded the specified capacity and modifies the `OverallCode`
@@ -455,13 +453,9 @@ namespace RiRi::Response {
         static_assert(std::is_trivially_copyable_v<EntryType>, "EntryType must be trivially copyable!!!");
         // A little reminder for him when his code doesn't compile.
 
-        constexpr StatusBatchWith() noexcept
-        :_entries{reinterpret_cast<EntryType *>(_static_store)},
-        _entry_count{0},
-        _capacity{VALUE_TRACKING_CAPACITY}
-        {
-            // *insert shrug here*
-        }
+        // Delete copy constructors
+        StatusBatchWith(const StatusBatchWith&) = delete;
+        StatusBatchWith& operator=(const StatusBatchWith&) = delete;
 
     private:
         /// The initial status code `ORPHANED`
@@ -474,10 +468,10 @@ namespace RiRi::Response {
         /// A unique pointer to manage an array of type EntryType
         std::unique_ptr<EntryType[]> _dynamic_store = nullptr;
 
-        /// Pointer that will track entries, initialized in constructor to point to STORE
-        EntryType *_entries = nullptr;
-        std::uint32_t _entry_count;
-        std::uint32_t _capacity;
+        /// Pointer that will track entries, initialized to point to _static_store
+        EntryType *_entries = reinterpret_cast<EntryType *>(_static_store);
+        std::uint32_t _entry_count = 0;
+        std::uint32_t _capacity = VALUE_TRACKING_CAPACITY;
 
         /**
          * @brief Increases the dynamic storage capacity for entries when the current capacity is not enough.

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -151,7 +151,7 @@ namespace RiRi::Response {
     };
 
     /**
-     * @brief Represents a full response structure used to track individual error status codes
+     * @brief Represents a Batched Status-Error response, used to track individual error status codes
      * when a command operates on multiple inputs or when multiple errors need to be reported together.
      *
      * This essentially holds a list of "errors"
@@ -174,24 +174,22 @@ namespace RiRi::Response {
     template <ResponseField F>
     class StatusErrorBatchWith {
 
-        // `RapidResponseFull` does four things:
+        // `StatusErrorBatchWith` does four things:
         // 1. Captures a blob or block of memory, statically.
         // 2. Makes the compiler treat the blob as if it stores elements of type `ErrorEntryType`
-        //    (a pair of `string_view` and `StatusCode`).
-        // 3. Constructs and stores an `ErrorEntryType` when `addFailure` is called and sets the status
+        //    (a pair of `ResponseField` and `StatusCode`).
+        // 3. Constructs and stores an `ErrorEntryType` when `addErrorEntry` is called and sets the status
         //    code to `ERR_SOME_OPERATIONS_FAILED`.
-        // 4. If `addFailure` is called beyond the blob’s capacity, the status is changed to
+        // 4. If `addErrorEntry` is called beyond the blob’s capacity, the status is changed to
         //    `ERR_MULTIPLE_OPERATIONS_FAILED`, and no further entries are added to the blob.
 
     public:
 
-        /** @brief Represents each OPERATION_TARGET-STATUS_CODE pair; this is how RiRi will carry individual
+        /** @brief Represents a FIELD_TARGET-STATUS_CODE pair; this is how RiRi will carry individual
          * status codes for each operation's target.
          *
-         * Operation Target? New term?
-         * Yes, not used widely at all inside RiRi, but understand that each operation has parameters or
-         * targets; more specifically, the target is the parameter that distinguishes or makes the said
-         * operation "identifiable".
+         * FIELD_TARGET is of type `ResponseField` and is usually of the intended type `string_view`. However,
+         * since `ResponseField` can also be `RapidDataType`, it is also supported programmatically.
          *
          * For instance, the following could be how one may get the response when trying to delete multiple keys
          * which don't exist in the map:
@@ -239,7 +237,7 @@ namespace RiRi::Response {
     public:
         // At this point, everything should be very self-explainable.
         /**
-         * @brief Adds a OPERATION_TARGET-STATUS_CODE pair to the Response's memory blob,
+         * @brief Adds a FIELD_TARGET-STATUS_CODE pair to the Response's memory blob,
          * only if there is no overflow.
          *
          * @param field_target : The target of an operation or an operation itself.
@@ -278,7 +276,8 @@ namespace RiRi::Response {
         }
 
         /**
-         * @brief Getter to return the total number of failures
+         * @brief Getter to return the total number of errors occurred, not
+         * necessarily equal to the number of entries in the response buffer.
          * @return _failure_count
          */
         [[nodiscard]] constexpr std::uint32_t totalErrorCount() const noexcept {
@@ -286,7 +285,7 @@ namespace RiRi::Response {
         }
 
         /**
-         * @brief Resets the RapidResponseFull state by clearing the failure count and
+         * @brief Resets the class state by clearing the failure count and
          * setting the overall status code to `StatusCode::OK`.
          */
         constexpr void reset() noexcept {

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -172,7 +172,8 @@ namespace RiRi::Response {
      * reported. If there are more errors than the tracking capacity, the overall status code becomes
      * ERR_MULTIPLE_OPERATIONS_FAILED and the rest of the errors are not tracked.
      */
-    class RapidResponseFull {
+    template <ResponseField F>
+    class StatusErrorBatchWith {
 
         // `RapidResponseFull` does four things:
         // 1. Captures a blob or block of memory, statically.
@@ -198,9 +199,9 @@ namespace RiRi::Response {
          * - `key3: ERR_KEY_NOT_FOUND`
          * - `key7: ERR_KEY_NOT_FOUND`
          */
-        using ErrorEntryType = std::pair<std::string_view, StatusCode>;
+        using ErrorEntryType = std::pair<F, StatusCode>;
 
-        RapidResponseFull() noexcept {
+        constexpr StatusErrorBatchWith() noexcept {
             // Pointer now points to the ERROR_STORE and will move by `ErrorEntryType`
             _failures = reinterpret_cast<ErrorEntryType*>(_error_store);
             // "Good Programming Principles," they said, "it will be less repetitive," they said.
@@ -242,10 +243,10 @@ namespace RiRi::Response {
          * @brief Adds a OPERATION_TARGET-STATUS_CODE pair to the Response's memory blob,
          * only if there is no overflow.
          *
-         * @param operation_target : The target of an operation or an operation itself.
+         * @param field_target : The target of an operation or an operation itself.
          * @param error_code : The error code concerning the operation target.
          */
-        void addFailure(std::string_view operation_target, StatusCode error_code) noexcept {
+        void addErrorEntry(F field_target, StatusCode error_code) noexcept {
 
             // We will always increase the failure count to keep track of the number of failures
             ++_failure_count;
@@ -255,7 +256,7 @@ namespace RiRi::Response {
             // A very neat use of `new`
             // Basically, we are "constructing" the pair at the `failures` position (`failure_count`).
             // Oh and yes, the memory is properly aligned and pre-allocated.
-            new(&_failures[_failure_count]) ErrorEntryType{operation_target, error_code};
+            new(&_failures[_failure_count]) ErrorEntryType{field_target, error_code};
 
             // And update the OverallCode to ERR_SOME_OPERATIONS_FAILED (406) as well.
             _overall_code = StatusCode::ERR_SOME_OPERATIONS_FAILED;
@@ -281,7 +282,7 @@ namespace RiRi::Response {
          * @brief Getter to return the total number of failures
          * @return _failure_count
          */
-        [[nodiscard]] constexpr std::uint32_t totalFailures() const noexcept {
+        [[nodiscard]] constexpr std::uint32_t totalErrorCount() const noexcept {
             return _failure_count;
         }
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -363,11 +363,12 @@ namespace RiRi::Response {
     * @note Regardless of the size of the static blob, the entirety of requested values (or StatusCode)
     * will be returned, nothing will be dropped.
      */
-    class RapidResponseValue{
+    template <ResponseField F1, ResponseField F2>
+    class StatusBatchWith{
     public:
 
         /// Either `Value` or `StatusCode` will be returned per fetch request
-        using ValueOrStatus = std::variant<RapidDataType*, StatusCode>;
+        using ResultOrStatus = std::variant<F2, StatusCode>;
 
         /**
          * @brief Represents each OPERATIONS_TARGET-VALUE_OR_STATUS pair; this is how RiRi will carry
@@ -379,7 +380,7 @@ namespace RiRi::Response {
          * - `Key2: ERR_KEY_NOT_FOUND`
          * - `Key3: Val3`
          */
-        using EntryType = std::pair<std::string_view, ValueOrStatus>;
+        using EntryType = std::pair<F1, ResultOrStatus>;
 
         // Just in case my future self decides to make the EntryType trivially non-destructible/copyable.
         static_assert(std::is_trivially_destructible_v<EntryType>,
@@ -388,7 +389,7 @@ namespace RiRi::Response {
           "EntryType must be trivially copyable!!!");
         // A little reminder for him when his code doesn't compile.
 
-        constexpr RapidResponseValue() noexcept
+        constexpr StatusBatchWith() noexcept
         :_entries{reinterpret_cast<EntryType *>(_static_store)},
         _entry_count{0},
         _capacity{VALUE_TRACKING_CAPACITY}
@@ -468,7 +469,7 @@ namespace RiRi::Response {
          * @param operation_target : The target of an operation or an operation itself.
          * @param entry : The value concerning the target.
          */
-        void addValue(std::string_view operation_target, RapidDataType* entry) noexcept {
+        void addResultEntry(F1 target_field, F2 result_field) noexcept {
             // We are going to update the OverallCode early, since this is the only error
             // code this function can return.
             // Update: We don't need to update the status code at all. This is the "OK" case,
@@ -480,17 +481,20 @@ namespace RiRi::Response {
             }
 
             // Construct OPERATION_TARGET-VALUE in STORE at entry_count.
-            new(&_entries[_entry_count]) EntryType{operation_target, entry};
+            new(&_entries[_entry_count]) EntryType{target_field, result_field};
             ++_entry_count;
         }
 
         /**
          * @brief Adds a OPERATION_TARGET-STATUS_CODE pair to the Response's memory blob.
-         * @param operation_target : The target of an operation or an operation itself
+         * @param target_field : The target of an operation or an operation itself
          * @param status_code : The value concerning the target
          */
-        void addStatus(std::string_view operation_target, StatusCode status_code) noexcept {
+        void addStatusEntry(F1 target_field, StatusCode status_code) noexcept {
             // shrugieeee
+
+            // TO-be-DO: THIS IS WRONG NOW, ADD A SIMPLE ERROR CODE CHECKER
+            // TO CHECK IF IT'S ACTUALLY AN ERROR CODE OR NOT AND THEN UPDATE
             _overall_code = StatusCode::ERR_SOME_OPERATIONS_FAILED;
 
             if (_entry_count >= _capacity) {
@@ -498,7 +502,7 @@ namespace RiRi::Response {
             }
 
             // Construct OPERATION_TARGET-STATUS_CODE in STORE at entry_count.
-            new(&_entries[_entry_count]) EntryType{operation_target, status_code};
+            new(&_entries[_entry_count]) EntryType{target_field, status_code};
             ++_entry_count;
         }
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -387,8 +387,8 @@ namespace RiRi::Response {
      * An example of a stored response:
      * [{"key2", "val2"}, {"key3", StatusCode::KEY_NOT_FOUND}, {...}, ...]
      *
-    * @note Regardless of the size of the static blob, the entirety of requested result (or StatusCode)
-    * will be returned, nothing will be dropped.
+    * @note Regardless of the size of the static blob, the entirety of the
+    * requested result (or StatusCode) will be returned, nothing will be dropped.
     * @note This class does not own the memory of the Fields.
      */
     template <ResponseField F1, ResponseField F2>
@@ -428,8 +428,8 @@ namespace RiRi::Response {
         }
 
     private:
-        /// The overall status code defaulted to `OK`. If errors, changes to `ERR_SOME_OPERATIONS_FAILED`
-        StatusCode _overall_code = StatusCode::OK;
+        /// The initial status code `ORPHANED`
+        StatusCode _overall_code = StatusCode::ORPHANED;
 
         /// A fixed blob or block of memory, which stores `EntryType` objects.
         alignas(EntryType)
@@ -475,6 +475,52 @@ namespace RiRi::Response {
             _capacity = new_capacity;          // Update capacity
         }
 
+        /**
+         * @brief Internal helper for determining the general status code based on status code
+         * @param status_code
+         * @return StatusCode
+         */
+        [[nodiscard]] static constexpr StatusCode determine_general_code(const StatusCode status_code) noexcept {
+            if (isSuccess(status_code) || isInfo(status_code)) {
+                return StatusCode::OK;
+            }
+            if (isWarning(status_code)) {
+                return StatusCode::WARN_RESPONSE_CONTAINS_WARNINGS;
+            }
+            // If it's not success, info, or warning, it must be an error
+            return StatusCode::ERR_SOME_OPERATIONS_FAILED;
+        }
+
+        /**
+         * @brief Internal overall code modifier based on status code
+         * @param status_code
+         */
+        constexpr void escalate_overall_code(const StatusCode status_code) noexcept {
+
+            // A tiny branch for cases like OK getting passed
+            // eh never mind, replacing a full register is faster than branching
+            // No wait, we need this, so that it doesn't go to that weird branch
+            // which computes general_code and stuff, not needed for same codes
+            if (_overall_code == status_code) { return; }
+
+            // 0. nuke case, do nothing since nothing can escalate this
+            if (_overall_code == StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED) { return; }
+
+            const StatusCode general_code = determine_general_code(status_code);
+
+            // 1. If ORPHANED, just set
+            if (_overall_code == StatusCode::ORPHANED) {
+                _overall_code = general_code;
+                return;
+            }
+
+            // 2. Otherwise, update based on severity ranking
+            // OK (0) < WARN_ (250) < ERR_ (406)
+            if (static_cast<std::uint16_t>(general_code) > static_cast<std::uint16_t>(_overall_code)) {
+                _overall_code = general_code;
+            }
+        }
+
     public:
 
         /**
@@ -513,6 +559,10 @@ namespace RiRi::Response {
             // Construct OPERATION_TARGET-VALUE in STORE at entry_count.
             new(&_entries[_entry_count]) EntryType{target_field, result_field};
             ++_entry_count;
+
+            // Since both fields are being added, clearly everything is okay! So, we try to
+            // escalate the overall-code with OK to overwrite the initial case
+            escalate_overall_code(StatusCode::OK);
         }
 
         /**
@@ -523,10 +573,6 @@ namespace RiRi::Response {
         void addStatusEntry(F1 target_field, StatusCode status_code) noexcept {
             // shrugieeee
 
-            // TO-be-DO: THIS IS WRONG NOW, ADD A SIMPLE ERROR CODE CHECKER
-            // TO CHECK IF IT'S ACTUALLY AN ERROR CODE OR NOT AND THEN UPDATE
-            _overall_code = StatusCode::ERR_SOME_OPERATIONS_FAILED;
-
             if (_entry_count >= _capacity) {
                 dynamically_grow();
             }
@@ -534,6 +580,8 @@ namespace RiRi::Response {
             // Construct OPERATION_TARGET-STATUS_CODE in STORE at entry_count.
             new(&_entries[_entry_count]) EntryType{target_field, status_code};
             ++_entry_count;
+
+            escalate_overall_code(status_code);
         }
 
         /**

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -320,10 +320,10 @@ namespace RiRi::Response {
      * This class encapsulates the response status code and a field value of the type ResponseField.
      * @note This class does not own memory
      */
-    template<ResponseField T>
+    template<ResponseField F>
     class StatusWith {
 
-        T _field { };
+        F _field { };
         StatusCode _status_code = StatusCode::ORPHANED;
 
     public:
@@ -332,14 +332,14 @@ namespace RiRi::Response {
 
         [[nodiscard]] bool ok() const noexcept { return _status_code == StatusCode::OK; }
 
-        [[nodiscard]] T field () const noexcept { return _field; }
+        [[nodiscard]] F field () const noexcept { return _field; }
 
-        void fill(const StatusCode code, T response_field) noexcept {
+        void fill(const StatusCode code, F response_field) noexcept {
             _field = response_field;
             _status_code = code;
         }
 
-        void setField(T response_field) noexcept { _field = response_field; }
+        void setField(F response_field) noexcept { _field = response_field; }
 
         void setCode(const StatusCode code) noexcept { _status_code = code; }
     };

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -247,10 +247,10 @@ namespace RiRi::Response {
         std::byte _error_store[TRACKING_CAPACITY * sizeof(ErrorEntryType)]{};
 
         /// Pointer that will track error entries, initialized in constructor to point to ERROR_STORE
-        ErrorEntryType *_failures = nullptr;     // Aptly named
+        ErrorEntryType *_failures = reinterpret_cast<ErrorEntryType*>(_error_store);;     // Aptly named
 
         // Pointer points to the ERROR_STORE and will move by `ErrorEntryType`
-        std::uint32_t _failure_count = reinterpret_cast<ErrorEntryType*>(_error_store);
+        std::uint32_t _failure_count = 0;
         std::uint8_t _capacity = TRACKING_CAPACITY;
 
         /**

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -261,7 +261,11 @@ namespace RiRi::Response {
          * @return True if the number of failures exceeds the capacity, otherwise false.
          */
         constexpr bool handle_overflow() noexcept {
-            if (_failure_count >= _capacity) {
+            // DEV NOTE: _failure_count is pre-incremented and represents the 1-based human count.
+            // We strictly use > instead of >= so the exact capacity-th item (e.g., the 8th error)
+            // evaluates to False, allowing it to be safely written to index [count - 1] (index 7).
+            // I WILL NOT TOUCH THIS CODE AGAIN. I AM DONE. PERIOD.
+            if (_failure_count > _capacity) {
                 _overall_code = StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED;
                 return true;
             }

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -1,13 +1,16 @@
 #pragma once
 
+#include <concepts>
 #include <cstdint>
-#include <string_view>
-#include <utility>
 #include <memory>
 #include <new>
-#include <concepts>
-
+#include <string_view>
+#include <utility>
 #include <RapidTypes.h>
+
+
+template <typename T>
+concept ResponseField = std::same_as<T, const RapidDataType*> || std::same_as<T, std::string_view>;
 
 /// This constant defines the number of errors to be tracked
 static constexpr size_t TRACKING_CAPACITY = 8;
@@ -313,13 +316,14 @@ namespace RiRi::Response {
 
 
     /**
-     * @brief A single-status-value response class
-     * This class encapsulates the response status code and a RapidDataType object (value).
+     * @brief A single status-field response class
+     * This class encapsulates the response status code and a field value of the type ResponseField.
      * @note This class does not own memory
      */
-    class RapidResponseOneValue {
+    template<ResponseField T>
+    class StatusWith {
 
-        const RapidDataType* _value = nullptr;
+        T _field { };
         StatusCode _status_code = StatusCode::ORPHANED;
 
     public:
@@ -328,14 +332,14 @@ namespace RiRi::Response {
 
         [[nodiscard]] bool ok() const noexcept { return _status_code == StatusCode::OK; }
 
-        [[nodiscard]] const RapidDataType* value () const noexcept { return _value; }
+        [[nodiscard]] T field () const noexcept { return _field; }
 
-        void fill(const RapidDataType* value, const StatusCode code) noexcept {
-            _value = value;
+        void fill(const StatusCode code, T response_field) noexcept {
+            _field = response_field;
             _status_code = code;
         }
 
-        void setValue(const RapidDataType* ptr) noexcept { _value = ptr; }
+        void setField(T response_field) noexcept { _field = response_field; }
 
         void setCode(const StatusCode code) noexcept { _status_code = code; }
     };

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -97,6 +97,10 @@ namespace RiRi::Response {
             // More to be added as RiRi grows.
             // Pretty sure I'd need more than 100
             // It looks like it's only for PARSER, but there will be THREAD, PERSISTENCE and SERVER levels too.
+
+        // SYSTEM ERROR CODES
+        ERR_OUT_OF_MEMORY = 600             // SYSTEM LEVEL
+            // fun
     };
 
     // helper functions to check what a status code's type is

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -347,21 +347,24 @@ namespace RiRi::Response {
 
 
     /**
-     * @brief Represents a value-returning response class to track individual values and error
-     * status codes when a command operates on multiple inputs or when multiple errors/values need
-     * to be reported together.
+     * @brief Represents a Batched Target_Field-Status_Field response class to track individual Target-Result
+     * or target-status_codes when a command operates on multiple targets or when multiple results/status codes
+     * need to be reported together.
      *
-     * `RapidResponseValue`'s functionality is largely similar to `RapidResponseFull` but
+     * `StatusBatchWith`'s functionality is largely similar to `StatusErrorBatchWith` but
      * with the following changes:
-     * - `EntryType` is a pair of `string_view` and either `StatusCode` or `RapidDataType*`
-     * - The default tracking (or value-returning capacity statically) is 16.
-     * - If `addFailure` or `addValue` is called beyond the static capacity, a dynamic array is initialized
-     *   and it grows dynamically.
+     * - `EntryType` is a pair of `ResponseField` (1) and either `StatusCode` or `ResponseField` (2)
+     * - The default tracking (or value-returning capacity statically) is 8.
+     * - If `addStatusEntry` or `addResultEntry` is called beyond the static capacity, a dynamic array is
+     *   initialized and it grows dynamically.
      *
-     * An example of a stored response containing a value and StatusCode:
+     * (1): The target field <- Input Field
+     * (2): The result field <- Output Field
+     *
+     * An example of a stored response:
      * [{"key2", "val2"}, {"key3", StatusCode::KEY_NOT_FOUND}, {...}, ...]
      *
-    * @note Regardless of the size of the static blob, the entirety of requested values (or StatusCode)
+    * @note Regardless of the size of the static blob, the entirety of requested result (or StatusCode)
     * will be returned, nothing will be dropped.
     * @note This class does not own the memory of the Fields.
      */
@@ -369,12 +372,12 @@ namespace RiRi::Response {
     class StatusBatchWith{
     public:
 
-        /// Either `Value` or `StatusCode` will be returned per fetch request
+        /// Either `ResponseField` (Result Field) or `StatusCode` will be returned per request
         using ResultOrStatus = std::variant<F2, StatusCode>;
 
         /**
-         * @brief Represents each OPERATIONS_TARGET-VALUE_OR_STATUS pair; this is how RiRi will carry
-         * individual return values (or StatusCode in case of errors) for each operation target.
+         * @brief Represents each TARGET_FIELD-FIELD_OR_STATUS pair; this is how raresy
+         * will carry individual result field (or StatusCode) for each operation target.
          *
          *  For instance, the following could be how one may get the response when trying to fetch multiple
          *  keys which may or may not exist in the map:
@@ -384,11 +387,13 @@ namespace RiRi::Response {
          */
         using EntryType = std::pair<F1, ResultOrStatus>;
 
-        // Just in case my future self decides to make the EntryType trivially non-destructible/copyable.
-        static_assert(std::is_trivially_destructible_v<EntryType>,
-          "EntryType must be trivially destructible!!!");
-        static_assert(std::is_trivially_copyable_v<EntryType>,
-          "EntryType must be trivially copyable!!!");
+        // We don't need static assert bloat when we got concepts
+        // ESPECIALLY INSIDE A TEMPLATE.
+        // // Just in case my future self decides to make the EntryType trivially non-destructible/copyable.
+        // static_assert(std::is_trivially_destructible_v<EntryType>,
+        //   "EntryType must be trivially destructible!!!");
+        // static_assert(std::is_trivially_copyable_v<EntryType>,
+        //   "EntryType must be trivially copyable!!!");
         // A little reminder for him when his code doesn't compile.
 
         constexpr StatusBatchWith() noexcept
@@ -466,10 +471,10 @@ namespace RiRi::Response {
         }
 
         /**
-         * @brief Adds a OPERATION_TARGET-VALUE pair to the Response's memory blob.
+         * @brief Adds a TARGET_FIELD-RESPONSE_FIELD pair to the Response's memory blob.
          *
-         * @param operation_target : The target of an operation or an operation itself.
-         * @param entry : The value concerning the target.
+         * @param target_field: The target of an operation or an operation itself.
+         * @param result_field: The result concerning the target.
          */
         void addResultEntry(F1 target_field, F2 result_field) noexcept {
             // We are going to update the OverallCode early, since this is the only error
@@ -488,9 +493,9 @@ namespace RiRi::Response {
         }
 
         /**
-         * @brief Adds a OPERATION_TARGET-STATUS_CODE pair to the Response's memory blob.
+         * @brief Adds a TARGET_field-STATUS_CODE pair to the Response's memory blob.
          * @param target_field : The target of an operation or an operation itself
-         * @param status_code : The value concerning the target
+         * @param status_code : The status code concerning the target
          */
         void addStatusEntry(F1 target_field, StatusCode status_code) noexcept {
             // shrugieeee

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -100,19 +100,18 @@ namespace RiRi::Response {
 
 
     /**
-     * @brief Represents a response class within the RapidResponse framework.
+     * @brief Represents a status containing response class within the Rapid Response System.
      *
-     * The `RapidResponse` class encapsulates the response status and
-     * provides helper functions within it to evaluate the `StatusCode` state.
+     * `Status` encapsulates the response status and provides helper
+     * functions within it to evaluate the `StatusCode` state.
      *
-     * It also provides a getter function to retrieve the response status.
+     * It also provides a getter function to retrieve the status code.
      *
      * This only holds the overall status code; even in cases where multiple
      * status codes might be required, in such cases, an appropriate status
-     * code showcasing the potential errors is used.
+     * code showcasing the potential errors may be used.
      *
      * Though let's be honest, you will still most likely use this, 90% of the time.
-     *
      */
     class Status {
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -229,6 +229,8 @@ namespace RiRi::Response {
          * - `key7: ERR_KEY_NOT_FOUND`
          */
         using ErrorEntryType = std::pair<F, StatusCode>;
+        static_assert(std::is_trivially_destructible_v<ErrorEntryType>, "EntryType must be trivially destructible!!!");
+        // Must be trivially destructible
 
         constexpr StatusErrorBatchWith() noexcept {
             // Pointer now points to the ERROR_STORE and will move by `ErrorEntryType`
@@ -259,7 +261,7 @@ namespace RiRi::Response {
          * @return True if the number of failures exceeds the capacity, otherwise false.
          */
         constexpr bool handle_overflow() noexcept {
-            if (_failure_count > _capacity) {
+            if (_failure_count >= _capacity) {
                 _overall_code = StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED;
                 return true;
             }
@@ -366,26 +368,26 @@ namespace RiRi::Response {
          * @brief Getter to return the overall status code
          * @return _status_code
          */
-        [[nodiscard]] StatusCode code() const noexcept { return _status_code; }
+        [[nodiscard]] constexpr StatusCode code() const noexcept { return _status_code; }
 
         /**
          * @brief Checks whether the status code is `StatusCode::OK`.
          * @return True if the status code is `StatusCode::OK`, otherwise false.
          */
-        [[nodiscard]] bool ok() const noexcept { return _status_code == StatusCode::OK; }
+        [[nodiscard]] constexpr bool ok() const noexcept { return _status_code == StatusCode::OK; }
 
         /**
          * @brief Getter to return the field object
          * @return ResponseField type object
          */
-        [[nodiscard]] F field () const noexcept { return _field; }
+        [[nodiscard]] constexpr F field () const noexcept { return _field; }
 
         /**
          * @brief Common setter to set both the status code and the field values
          * @param code The status code of type StatusCode
          * @param response_field The field of type ResponseField to set
          */
-        void fill(const StatusCode code, F response_field) noexcept {
+        void constexpr fill(const StatusCode code, F response_field) noexcept {
             _field = response_field;
             _status_code = code;
         }
@@ -394,13 +396,13 @@ namespace RiRi::Response {
          * @brief Setter to set the field value of the response
          * @param response_field The field of type ResponseField
          */
-        void setField(F response_field) noexcept { _field = response_field; }
+        void constexpr setField(F response_field) noexcept { _field = response_field; }
 
         /**
          * @brief Setter to set the status code of the response
          * @param code The status code of type StatusCode
          */
-        void setCode(const StatusCode code) noexcept { _status_code = code; }
+        void constexpr setCode(const StatusCode code) noexcept { _status_code = code; }
     };
 
 
@@ -445,13 +447,8 @@ namespace RiRi::Response {
          */
         using EntryType = std::pair<F1, ResultOrStatus>;
 
-        // We don't need static assert bloat when we got concepts
-        // ESPECIALLY INSIDE A TEMPLATE.
-        // // Just in case my future self decides to make the EntryType trivially non-destructible/copyable.
-        // static_assert(std::is_trivially_destructible_v<EntryType>,
-        //   "EntryType must be trivially destructible!!!");
-        // static_assert(std::is_trivially_copyable_v<EntryType>,
-        //   "EntryType must be trivially copyable!!!");
+        // Just in case my future self decides to make the EntryType trivially non-copyable.
+        static_assert(std::is_trivially_copyable_v<EntryType>, "EntryType must be trivially copyable!!!");
         // A little reminder for him when his code doesn't compile.
 
         constexpr StatusBatchWith() noexcept
@@ -529,8 +526,12 @@ namespace RiRi::Response {
          */
         [[nodiscard]] static constexpr StatusCode determine_general_code(const StatusCode status_code) noexcept {
             const auto val = static_cast<std::uint16_t>(status_code);
-            if (val < 200) return StatusCode::OK;         // success + info
+
+            // Success and Info codes can all be under OK general code
+            if (val < 200) return StatusCode::OK;
+            // Warnings
             if (val < 400) return StatusCode::WARN_RESPONSE_CONTAINS_WARNINGS;
+            // If not success, infor or warn; has to be error
             return StatusCode::ERR_SOME_OPERATIONS_FAILED;
         }
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -170,6 +170,8 @@ namespace RiRi::Response {
      * @note The tracking capacity is manually set; by default, set to 8. This means only 8 errors will be
      * reported. If there are more errors than the tracking capacity, the overall status code becomes
      * ERR_MULTIPLE_OPERATIONS_FAILED and the rest of the errors are not tracked.
+     *
+     * @note This class does not own the target field's memory
      */
     template <ResponseField F>
     class StatusErrorBatchWith {
@@ -317,7 +319,7 @@ namespace RiRi::Response {
     /**
      * @brief A single status-field response class
      * This class encapsulates the response status code and a field value of the type ResponseField.
-     * @note This class does not own memory
+     * @note This class does not own field's memory
      */
     template<ResponseField F>
     class StatusWith {
@@ -361,6 +363,7 @@ namespace RiRi::Response {
      *
     * @note Regardless of the size of the static blob, the entirety of requested values (or StatusCode)
     * will be returned, nothing will be dropped.
+    * @note This class does not own the memory of the Fields.
      */
     template <ResponseField F1, ResponseField F2>
     class StatusBatchWith{

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -114,14 +114,14 @@ namespace RiRi::Response {
      * Though let's be honest, you will still most likely use this, 90% of the time.
      *
      */
-    class RapidResponse {
+    class Status {
 
     public:
         // Default constructor initializes `response` to the most common case.
-        RapidResponse() noexcept : response(StatusCode::OK) {}
+        Status() noexcept : response(StatusCode::OK) {}
 
         // Explicit constructor to initialize `response` with StatusCode types.
-        explicit RapidResponse(StatusCode status_code) noexcept : response(status_code) {}
+        explicit Status(StatusCode status_code) noexcept : response(status_code) {}
 
     private:
         /// Represents a single status outcome — either from a single operation
@@ -130,7 +130,7 @@ namespace RiRi::Response {
 
     public:
 
-        constexpr void addCode(StatusCode status_code) noexcept {
+        constexpr void setCode(StatusCode status_code) noexcept {
             response = status_code;
         }
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -117,37 +117,37 @@ namespace RiRi::Response {
     class Status {
 
     public:
-        // Default constructor initializes `response` to the most common case.
-        Status() noexcept : response(StatusCode::OK) {}
+        // The default constructor initializes `_status_code` to the most common case.
+        Status() noexcept : _status_code(StatusCode::OK) {}
 
-        // Explicit constructor to initialize `response` with StatusCode types.
-        explicit Status(StatusCode status_code) noexcept : response(status_code) {}
+        // Explicit constructor to initialize `_status_code` with StatusCode types.
+        explicit Status(StatusCode status_code) noexcept : _status_code(status_code) {}
 
     private:
         /// Represents a single status outcome — either from a single operation
         /// or an overall result when no per-operation diagnostics are needed.
-        StatusCode response;
+        StatusCode _status_code;
 
     public:
 
-        constexpr void setCode(StatusCode status_code) noexcept {
-            response = status_code;
+        constexpr void setCode(const StatusCode status_code) noexcept {
+            _status_code = status_code;
         }
 
         /**
-         * @brief Returns the response of the container
+         * @brief Returns the status_code of the response
          * @return StatusCode
          */
         [[nodiscard]] constexpr StatusCode code() const noexcept {
-            return response;
+            return _status_code;
         }
 
         /**
-         * @brief Checks if the response status is successful.
+         * @brief Checks if the status code is OK.
          * @return `true` if the response status is `StatusCode::OK`, otherwise false.
          */
         [[nodiscard]] constexpr bool ok() const noexcept {
-            return response == StatusCode::OK;
+            return _status_code == StatusCode::OK;
         }
     };
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -143,6 +143,8 @@ namespace RiRi::Response {
     class Status {
 
     public:
+        // default formality constructor
+        constexpr Status() noexcept = default;
         // Explicit constructor to initialize `_status_code` with StatusCode types.
         explicit Status(StatusCode status_code) noexcept : _status_code(status_code) {}
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -53,7 +53,8 @@ namespace RiRi::Response {
             // Basically, the response is currently empty and pending assignment.
 
         // WARNING CODES (200-299)
-        WARN_KEY_STORE_NEARING_CAPACITY = 200,  // COMMAND LEVEL
+        WARN_KEY_STORE_NEARING_CAPACITY = 200,      // COMMAND LEVEL
+        WARN_RESPONSE_CONTAINS_WARNINGS = 250,      // RESPONSE LEVEL
             // We might need warning codes, and a lot of them.
 
         // BUFFER RANGE (300-399)
@@ -97,6 +98,28 @@ namespace RiRi::Response {
             // Pretty sure I'd need more than 100
             // It looks like it's only for PARSER, but there will be THREAD, PERSISTENCE and SERVER levels too.
     };
+
+    // helper functions to check what a status code's type is
+
+    [[nodiscard]] constexpr bool isSuccess(StatusCode code) noexcept {
+        const auto val = static_cast<std::uint16_t>(code);
+        return val < 100;
+    }
+
+    [[nodiscard]] constexpr bool isInfo(StatusCode code) noexcept {
+        const auto val = static_cast<std::uint16_t>(code);
+        return val >= 100 && val < 200;
+    }
+
+    [[nodiscard]] constexpr bool isWarning(StatusCode code) noexcept {
+        const auto val = static_cast<std::uint16_t>(code);
+        return val >= 200 && val < 400; // Includes the 300-400 buffer range for now
+    }
+
+    [[nodiscard]] constexpr bool isError(StatusCode code) noexcept {
+        const auto val = static_cast<std::uint16_t>(code);
+        return val >= 400; // Covers errors and beyond
+    }
 
 
     /**

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -236,6 +236,18 @@ namespace RiRi::Response {
         StatusErrorBatchWith(const StatusErrorBatchWith&) = delete;
         StatusErrorBatchWith& operator=(const StatusErrorBatchWith&) = delete;
 
+        // move constructor (in case NRVO fails; likely never)
+        StatusErrorBatchWith(StatusErrorBatchWith&& obj) noexcept
+        : _overall_code(obj._overall_code),
+        _failure_count(obj._failure_count),
+        _capacity(obj._capacity)
+        {
+            std::memcpy(_error_store, obj._error_store, _capacity * sizeof(ErrorEntryType));
+
+            // reset
+            obj._failure_count = 0;
+            obj._overall_code = StatusCode::OK;
+        }
 
     private:
 
@@ -474,6 +486,7 @@ namespace RiRi::Response {
             // resetting our obj
             obj._entries = reinterpret_cast<EntryType*>(obj._static_store);
             obj._entry_count = 0;
+            obj._overall_code = StatusCode::ORPHANED;
         }
 
     private:

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -457,6 +457,25 @@ namespace RiRi::Response {
         StatusBatchWith(const StatusBatchWith&) = delete;
         StatusBatchWith& operator=(const StatusBatchWith&) = delete;
 
+        // move constructor (in case NRVO fails; likely never)
+        StatusBatchWith(StatusBatchWith&& obj) noexcept
+        : _overall_code(obj._overall_code),
+        _dynamic_store(std::move(obj._dynamic_store)),
+        _entry_count(obj._entry_count),
+        _capacity(obj._capacity)
+        {
+            // if static buffer, we copy it.
+            if (obj._entries == reinterpret_cast<EntryType *>(obj._static_store)) {
+                std::memcpy(_static_store, obj._static_store, _entry_count * sizeof(EntryType));
+            } else {
+                // else it's dynamic, so we just snatch it.
+                _entries = obj._entries;
+            }
+            // resetting our obj
+            obj._entries = reinterpret_cast<EntryType*>(obj._static_store);
+            obj._entry_count = 0;
+        }
+
     private:
         /// The initial status code `ORPHANED`
         StatusCode _overall_code = StatusCode::ORPHANED;

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -180,187 +180,6 @@ namespace RiRi::Response {
         }
     };
 
-    /**
-     * @brief Represents a Batched Status-Error response, used to track individual error status codes
-     * when a command operates on multiple inputs or when multiple errors need to be reported together.
-     *
-     * This essentially holds a list of "errors"
-     *
-     * For instance, this is what a stored response might look like:
-     *  [{"key2", StatusCode::KEY_NOT_FOUND}, {"Key3", StatusCode::INVALID_ARGS}, {...}, ...]
-     *
-     * Also holds and tracks the total number of errors.
-     *
-     * Made with agony for the 10% use cases :D
-     *
-     * @note Success cases are not tracked, and the absence of keys in the response means the set was successful
-     * unless the overall code is `ERR_MULTIPLE_OPERATIONS_FAILED`, in which case... good luck I guess (you bought
-     * this on yourself honestly).
-     *
-     * @note The tracking capacity is manually set; by default, set to 8. This means only 8 errors will be
-     * reported. If there are more errors than the tracking capacity, the overall status code becomes
-     * ERR_MULTIPLE_OPERATIONS_FAILED and the rest of the errors are not tracked.
-     *
-     * @note This class does not own the target field's memory
-     */
-    template <ResponseField F>
-    class StatusErrorBatchWith {
-
-        // `StatusErrorBatchWith` does four things:
-        // 1. Captures a blob or block of memory, statically.
-        // 2. Makes the compiler treat the blob as if it stores elements of type `ErrorEntryType`
-        //    (a pair of `ResponseField` and `StatusCode`).
-        // 3. Constructs and stores an `ErrorEntryType` when `addErrorEntry` is called and sets the status
-        //    code to `ERR_SOME_OPERATIONS_FAILED`.
-        // 4. If `addErrorEntry` is called beyond the blob’s capacity, the status is changed to
-        //    `ERR_MULTIPLE_OPERATIONS_FAILED`, and no further entries are added to the blob.
-
-    public:
-
-        /** @brief Represents a FIELD_TARGET-STATUS_CODE pair; this is how RiRi will carry individual
-         * status codes for each operation's target.
-         *
-         * FIELD_TARGET is of type `ResponseField` and is usually of the intended type `string_view`. However,
-         * since `ResponseField` can also be `RapidDataType`, it is also supported programmatically.
-         *
-         * For instance, the following could be how one may get the response when trying to delete multiple keys
-         * which don't exist in the map:
-         * - `key3: ERR_KEY_NOT_FOUND`
-         * - `key7: ERR_KEY_NOT_FOUND`
-         */
-        using ErrorEntryType = std::pair<F, StatusCode>;
-        static_assert(std::is_trivially_destructible_v<ErrorEntryType>, "EntryType must be trivially destructible!!!");
-        // Must be trivially destructible
-
-        // Delete the copy constructors
-        StatusErrorBatchWith(const StatusErrorBatchWith&) = delete;
-        StatusErrorBatchWith& operator=(const StatusErrorBatchWith&) = delete;
-
-        // move constructor (in case NRVO fails; likely never)
-        StatusErrorBatchWith(StatusErrorBatchWith&& obj) noexcept
-        : _overall_code(obj._overall_code),
-        _failure_count(obj._failure_count),
-        _capacity(obj._capacity)
-        {
-            std::memcpy(_error_store, obj._error_store, _capacity * sizeof(ErrorEntryType));
-
-            // reset
-            obj._failure_count = 0;
-            obj._overall_code = StatusCode::OK;
-        }
-
-    private:
-
-        /// The overall status code defaulted to OK; if it stays OK, you are fine (probably).
-        StatusCode _overall_code = StatusCode::OK;
-
-        /// A fixed blob or block of memory, which stores `ErrorEntryType` objects.
-        alignas(ErrorEntryType)
-        std::byte _error_store[TRACKING_CAPACITY * sizeof(ErrorEntryType)]{};
-
-        /// Pointer that will track error entries, initialized in constructor to point to ERROR_STORE
-        ErrorEntryType *_failures = reinterpret_cast<ErrorEntryType*>(_error_store);;     // Aptly named
-
-        // Pointer points to the ERROR_STORE and will move by `ErrorEntryType`
-        std::uint32_t _failure_count = 0;
-        std::uint8_t _capacity = TRACKING_CAPACITY;
-
-        /**
-         * @brief Checks if the number of failures has exceeded the specified capacity and modifies the `OverallCode`
-         * to `ERR_MULTIPLE_OPERATIONS_FAILED` if needed.
-         * @return True if the number of failures exceeds the capacity, otherwise false.
-         */
-        constexpr bool handle_overflow() noexcept {
-            // DEV NOTE: _failure_count is pre-incremented and represents the 1-based human count.
-            // We strictly use > instead of >= so the exact capacity-th item (e.g., the 8th error)
-            // evaluates to False, allowing it to be safely written to index [count - 1] (index 7).
-            // I WILL NOT TOUCH THIS CODE AGAIN. I AM DONE. PERIOD.
-            if (_failure_count > _capacity) {
-                _overall_code = StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED;
-                return true;
-            }
-            return false;
-        }
-
-    public:
-        // At this point, everything should be very self-explainable.
-        /**
-         * @brief Adds a FIELD_TARGET-STATUS_CODE pair to the Response's memory blob,
-         * only if there is no overflow.
-         *
-         * @param field_target : The target of an operation or an operation itself.
-         * @param error_code : The error code concerning the operation target.
-         */
-        void addErrorEntry(F field_target, StatusCode error_code) noexcept {
-
-            // We will always increase the failure count to keep track of the number of failures
-            ++_failure_count;
-
-            if (handle_overflow()) return;
-
-            // A very neat use of `new`
-            // Basically, we are "constructing" the pair at the `failures` position (`failure_count`).
-            // Oh and yes, the memory is properly aligned and pre-allocated.
-            new(&_failures[_failure_count-1]) ErrorEntryType{field_target, error_code};
-
-            // And update the OverallCode to ERR_SOME_OPERATIONS_FAILED (406) as well.
-            _overall_code = StatusCode::ERR_SOME_OPERATIONS_FAILED;
-        }
-
-        /**
-         * @brief Checks whether the overall status code is `StatusCode::OK`.
-         * @return True if the overall status code is `StatusCode::OK`, otherwise false.
-         */
-        [[nodiscard]] constexpr bool ok() const noexcept {
-            return _overall_code == StatusCode::OK;
-        }
-
-        /**
-         * @brief Getter to return the overall status code
-         * @return _overall_code
-         */
-        [[nodiscard]] constexpr StatusCode code() const noexcept {
-            return _overall_code;
-        }
-
-        /**
-         * @brief Getter to return the total number of errors occurred, not
-         * necessarily equal to the number of entries in the response buffer.
-         * @return _failure_count
-         */
-        [[nodiscard]] constexpr std::uint32_t totalErrorCount() const noexcept {
-            return _failure_count;
-        }
-
-        /**
-         * @brief Resets the class state by clearing the failure count and
-         * setting the overall status code to `StatusCode::OK`.
-         */
-        constexpr void reset() noexcept {
-            _failure_count = 0;
-            _overall_code = StatusCode::OK;
-
-            // No destructors needed since we only hold trivially destructible types
-        }
-
-        /**
-         * @brief Provides a constant iterator pointing to the beginning of the `failures` collection.
-         * @return A pointer to the first error entry in the failure collection.
-         */
-        [[nodiscard]] constexpr auto begin() const noexcept { return _failures; }
-
-        /**
-         * @brief Provides a constant iterator pointing to the end of the `failures` collection.
-         * @return A pointer to one past the last error entry in the failure collection.
-         */
-        [[nodiscard]] constexpr auto end() const noexcept {
-            // only iterate up to the capacity or failure count; whichever is lower
-            return _failures + (_failure_count > _capacity ? _capacity : _failure_count);
-        }
-
-        // you're welcome for the iterators.
-    };
-
 
     /**
      * @brief A single status-field response class
@@ -686,6 +505,188 @@ namespace RiRi::Response {
          */
         [[nodiscard]] constexpr auto end() const noexcept { return _entries + _entry_count; }
 
+    };
+
+
+     /**
+     * @brief Represents a Batched Status-Error response, used to track individual error status codes
+     * when a command operates on multiple inputs or when multiple errors need to be reported together.
+     *
+     * This essentially holds a list of "errors"
+     *
+     * For instance, this is what a stored response might look like:
+     *  [{"key2", StatusCode::KEY_NOT_FOUND}, {"Key3", StatusCode::INVALID_ARGS}, {...}, ...]
+     *
+     * Also holds and tracks the total number of errors.
+     *
+     * Made with agony for the 10% use cases :D
+     *
+     * @note Success cases are not tracked, and the absence of keys in the response means the set was successful
+     * unless the overall code is `ERR_MULTIPLE_OPERATIONS_FAILED`, in which case... good luck I guess (you bought
+     * this on yourself honestly).
+     *
+     * @note The tracking capacity is manually set; by default, set to 8. This means only 8 errors will be
+     * reported. If there are more errors than the tracking capacity, the overall status code becomes
+     * ERR_MULTIPLE_OPERATIONS_FAILED and the rest of the errors are not tracked.
+     *
+     * @note This class does not own the target field's memory
+     */
+    template <ResponseField F>
+    class StatusErrorBatchWith {
+
+        // `StatusErrorBatchWith` does four things:
+        // 1. Captures a blob or block of memory, statically.
+        // 2. Makes the compiler treat the blob as if it stores elements of type `ErrorEntryType`
+        //    (a pair of `ResponseField` and `StatusCode`).
+        // 3. Constructs and stores an `ErrorEntryType` when `addErrorEntry` is called and sets the status
+        //    code to `ERR_SOME_OPERATIONS_FAILED`.
+        // 4. If `addErrorEntry` is called beyond the blob’s capacity, the status is changed to
+        //    `ERR_MULTIPLE_OPERATIONS_FAILED`, and no further entries are added to the blob.
+
+    public:
+
+        /** @brief Represents a FIELD_TARGET-STATUS_CODE pair; this is how RiRi will carry individual
+         * status codes for each operation's target.
+         *
+         * FIELD_TARGET is of type `ResponseField` and is usually of the intended type `string_view`. However,
+         * since `ResponseField` can also be `RapidDataType`, it is also supported programmatically.
+         *
+         * For instance, the following could be how one may get the response when trying to delete multiple keys
+         * which don't exist in the map:
+         * - `key3: ERR_KEY_NOT_FOUND`
+         * - `key7: ERR_KEY_NOT_FOUND`
+         */
+        using ErrorEntryType = std::pair<F, StatusCode>;
+        static_assert(std::is_trivially_destructible_v<ErrorEntryType>, "EntryType must be trivially destructible!!!");
+        // Must be trivially destructible
+
+        // Delete the copy constructors
+        StatusErrorBatchWith(const StatusErrorBatchWith&) = delete;
+        StatusErrorBatchWith& operator=(const StatusErrorBatchWith&) = delete;
+
+        // move constructor (in case NRVO fails; likely never)
+        StatusErrorBatchWith(StatusErrorBatchWith&& obj) noexcept
+        : _overall_code(obj._overall_code),
+        _failure_count(obj._failure_count),
+        _capacity(obj._capacity)
+        {
+            std::memcpy(_error_store, obj._error_store, _capacity * sizeof(ErrorEntryType));
+
+            // reset
+            obj._failure_count = 0;
+            obj._overall_code = StatusCode::OK;
+        }
+
+    private:
+
+        /// The overall status code defaulted to OK; if it stays OK, you are fine (probably).
+        StatusCode _overall_code = StatusCode::OK;
+
+        /// A fixed blob or block of memory, which stores `ErrorEntryType` objects.
+        alignas(ErrorEntryType)
+        std::byte _error_store[TRACKING_CAPACITY * sizeof(ErrorEntryType)]{};
+
+        /// Pointer that will track error entries, initialized in constructor to point to ERROR_STORE
+        ErrorEntryType *_failures = reinterpret_cast<ErrorEntryType*>(_error_store);;     // Aptly named
+
+        // Pointer points to the ERROR_STORE and will move by `ErrorEntryType`
+        std::uint32_t _failure_count = 0;
+        std::uint8_t _capacity = TRACKING_CAPACITY;
+
+        /**
+         * @brief Checks if the number of failures has exceeded the specified capacity and modifies the `OverallCode`
+         * to `ERR_MULTIPLE_OPERATIONS_FAILED` if needed.
+         * @return True if the number of failures exceeds the capacity, otherwise false.
+         */
+        constexpr bool handle_overflow() noexcept {
+            // DEV NOTE: _failure_count is pre-incremented and represents the 1-based human count.
+            // We strictly use > instead of >= so the exact capacity-th item (e.g., the 8th error)
+            // evaluates to False, allowing it to be safely written to index [count - 1] (index 7).
+            // I WILL NOT TOUCH THIS CODE AGAIN. I AM DONE. PERIOD.
+            if (_failure_count > _capacity) {
+                _overall_code = StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED;
+                return true;
+            }
+            return false;
+        }
+
+    public:
+        // At this point, everything should be very self-explainable.
+        /**
+         * @brief Adds a FIELD_TARGET-STATUS_CODE pair to the Response's memory blob,
+         * only if there is no overflow.
+         *
+         * @param field_target : The target of an operation or an operation itself.
+         * @param error_code : The error code concerning the operation target.
+         */
+        void addErrorEntry(F field_target, StatusCode error_code) noexcept {
+
+            // We will always increase the failure count to keep track of the number of failures
+            ++_failure_count;
+
+            if (handle_overflow()) return;
+
+            // A very neat use of `new`
+            // Basically, we are "constructing" the pair at the `failures` position (`failure_count`).
+            // Oh and yes, the memory is properly aligned and pre-allocated.
+            new(&_failures[_failure_count-1]) ErrorEntryType{field_target, error_code};
+
+            // And update the OverallCode to ERR_SOME_OPERATIONS_FAILED (406) as well.
+            _overall_code = StatusCode::ERR_SOME_OPERATIONS_FAILED;
+        }
+
+        /**
+         * @brief Checks whether the overall status code is `StatusCode::OK`.
+         * @return True if the overall status code is `StatusCode::OK`, otherwise false.
+         */
+        [[nodiscard]] constexpr bool ok() const noexcept {
+            return _overall_code == StatusCode::OK;
+        }
+
+        /**
+         * @brief Getter to return the overall status code
+         * @return _overall_code
+         */
+        [[nodiscard]] constexpr StatusCode code() const noexcept {
+            return _overall_code;
+        }
+
+        /**
+         * @brief Getter to return the total number of errors occurred, not
+         * necessarily equal to the number of entries in the response buffer.
+         * @return _failure_count
+         */
+        [[nodiscard]] constexpr std::uint32_t totalErrorCount() const noexcept {
+            return _failure_count;
+        }
+
+        /**
+         * @brief Resets the class state by clearing the failure count and
+         * setting the overall status code to `StatusCode::OK`.
+         */
+        constexpr void reset() noexcept {
+            _failure_count = 0;
+            _overall_code = StatusCode::OK;
+
+            // No destructors needed since we only hold trivially destructible types
+        }
+
+        /**
+         * @brief Provides a constant iterator pointing to the beginning of the `failures` collection.
+         * @return A pointer to the first error entry in the failure collection.
+         */
+        [[nodiscard]] constexpr auto begin() const noexcept { return _failures; }
+
+        /**
+         * @brief Provides a constant iterator pointing to the end of the `failures` collection.
+         * @return A pointer to one past the last error entry in the failure collection.
+         */
+        [[nodiscard]] constexpr auto end() const noexcept {
+            // only iterate up to the capacity or failure count; whichever is lower
+            return _failures + (_failure_count > _capacity ? _capacity : _failure_count);
+        }
+
+        // you're welcome for the iterators.
     };
 }
 

--- a/src/utils/RapidResponse.hpp
+++ b/src/utils/RapidResponse.hpp
@@ -151,7 +151,10 @@ namespace RiRi::Response {
         StatusCode _status_code;
 
     public:
-
+        /**
+         * @brief Setter to set the status code of the response
+         * @param status_code The status code to be set
+         */
         constexpr void setCode(const StatusCode status_code) noexcept {
             _status_code = status_code;
         }
@@ -347,24 +350,52 @@ namespace RiRi::Response {
     template<ResponseField F>
     class StatusWith {
 
+        /// The field value: initialized to default values
         F _field { };
+
+        /// The status code: initialized to the default status code ORPHANED
         StatusCode _status_code = StatusCode::ORPHANED;
 
     public:
 
+        /**
+         * @brief Getter to return the overall status code
+         * @return _status_code
+         */
         [[nodiscard]] StatusCode code() const noexcept { return _status_code; }
 
+        /**
+         * @brief Checks whether the status code is `StatusCode::OK`.
+         * @return True if the status code is `StatusCode::OK`, otherwise false.
+         */
         [[nodiscard]] bool ok() const noexcept { return _status_code == StatusCode::OK; }
 
+        /**
+         * @brief Getter to return the field object
+         * @return ResponseField type object
+         */
         [[nodiscard]] F field () const noexcept { return _field; }
 
+        /**
+         * @brief Common setter to set both the status code and the field values
+         * @param code The status code of type StatusCode
+         * @param response_field The field of type ResponseField to set
+         */
         void fill(const StatusCode code, F response_field) noexcept {
             _field = response_field;
             _status_code = code;
         }
 
+        /**
+         * @brief Setter to set the field value of the response
+         * @param response_field The field of type ResponseField
+         */
         void setField(F response_field) noexcept { _field = response_field; }
 
+        /**
+         * @brief Setter to set the status code of the response
+         * @param code The status code of type StatusCode
+         */
         void setCode(const StatusCode code) noexcept { _status_code = code; }
     };
 
@@ -477,7 +508,7 @@ namespace RiRi::Response {
 
         /**
          * @brief Internal helper for determining the general status code based on status code
-         * @param status_code
+         * @param status_code The StausCode to find the general code of.
          * @return StatusCode
          */
         [[nodiscard]] static constexpr StatusCode determine_general_code(const StatusCode status_code) noexcept {
@@ -489,7 +520,7 @@ namespace RiRi::Response {
 
         /**
          * @brief Internal overall code modifier based on status code
-         * @param status_code
+         * @param status_code The added StatusCode to update the overall code accordingly.
          */
         constexpr void escalate_overall_code(const StatusCode status_code) noexcept {
 


### PR DESCRIPTION
# Major refactor of the Rapid Response System

Resolves #28 - RaReSy can be optimized for usage with better generalized types

Another day, another refactor of `RapidResponse.hpp` .
This file has 50+ commits touching it (including squashed commits), for reference the main branch has 53 commits as of today.
And this PR alone has 27 commits touching just that file alone
Point being... it. never. ends.
Anyways, I digress.

---
Aight firstly, the old system we got rid of (at least on the surface):
- `RapidResponse` class (held single `StatusCode` type object)
- `RapidResponseFull` class (held `StatusCode` and `string_view` types, batched till 8).
- `RapidResponseOneValue` class (held single `StatusCode` and `RapidDataType*` type objects) 
- `RapidResponseValue` class (held `string_view`, and `RapidDataType*` or `StatusCode` types, batched).

The implementation of the above classes carried over to the new classes (or rather these classes just got templated), and the new system we have now is:
- `Status` class (holds single `StatusCode` type object)
- `StatusWith<F>` class (holds single `StatusCode` and `ResponseField` type object)
- `StatusBatchWith<F1, F2>` class (holds batched `ResponseField`[target], and `ResponseField`[result] or `StatusCode` objects)
- `StatusErrorBatchWith<F>` class (holds batched `ResponseField`[target] and `StatusCode` objects, limited by a fixed configurable count).

All were named like so because the namespace is named `Response`, and `Response::StatusBatchWith<F1, F2>` sounds much better than `Response::RapidResponseValue`. The names of these classes are intended to specify what they are holding, for instance, `StatusBatchWith` implies that there is a `StatusCode` in the response object, along with pairs of F1-F2 type objects, and all are batched, means there are multiple such objects in the response, for specifics on how these objects are ordered or present, refer individual class docs.


### What types are the classes templated with? `ResponseField`?

Yes, instead of just templating the classes with `typename T`, I created a constrained type which can only be of two types; `StatusCode` and `const RapidDataType*`, together called `ResponseField`

C++20's `concepts` was used to define this type constrain, like so:
```cpp
#include <concepts>

template <typename T>
concept ResponseField = std::same_as<T, const RapidDataType*> || std::same_as<T, std::string_view>;
```

With this, the compiler will refuse to even compile if any other types are passed. Additionally, with this we have generalized the classes to support multiple types, meaning we really don't have 4 classes but 9 classes if we consider all permutations of F.

For our current use case, I agree that fixed types were enough but hardcoding the types meant I would need to create more classes if I needed anything more specific (say I needed a batched response for setting multiple keys, but I don't want RiRi to drop any responses, the older system had no such classes to support this since keys are strictly of type `string`).

### Constructors

All the classes which flirted with memory had their copy constructors deleted and you cannot copy these class objects (deal with it). 

And since deleting the copy constructors meant saying bye bye to default move constructors, move constructors were added. This is necessary, since returning these objects via functions would be impossible (inconvenient). Though, this custom move constructor will not be called 99% of the time due to NRVO, the compiler just wanted a safety net to fall back to (more like "prove it to me that this thing is actually movable nerd").

These changes only applies to:
- `StatusBatchWith<F1, F2>`
- `StatusErrorBatchWith<F>`  
 
---

### Class specific changes

**1. OOM Handling inside `StatusBatchWith<F1, F2>**

`StatusBatchWith<F1, F2>` has a private `dynamically_grow()` function, which claims new memory from the system for creating a new dynamically allocated buffer of a larger size. This function can sometimes return `std::bad_alloc` when the system runs Out Of Memory (OOM). To handle this:
- Firstly, `StatusCode::ERR_OUT_OF_MEMORY` (600) was added to the status code enum
- `dynamically_grow()` was refactored to return bool values
- On encountering `std::bad_alloc` while growing, `dynamically_grow()` will return `false` and the overall status code is updated to `ERR_OUT_OF_MEMORY`. 
- All internal public functions check the overall status code before executing their objectives, if it's ever `ERR_OUT_OF_MEMORY` all functions bail out.

**2. Status code escalation inside `StatusBatchWith<F1, F2>**

`StatusBatchWith<F1, F2>` (previously `RapidResponseValue`) used to initialize overall status code to `StatusCode::OK`, but now with the addition of `StatusCode::OPRHANED`, it now initializes to `StatusCode::ORPHANED`. However, this introduced a need for a refactor of status code update logic.

Since the overall status code defaulted to OK on initialization, we never needed to update the overall status code on success paths (`addFieldEntry(...)`). With ORPHANED being the default case we now need to update the overall status code on success path as well.

Additionally, since our class was more generalized now, we can no longer update the overall status code directly (previously we just set it to `ERR_SOME_OPERATIONS_FAILED`). Hence `escalate_overall_code(...)` was added. It takes the status code (which is being added to the buffer) and passes it to another helper function (`determine_general_code(...)`) to determine what general status code can represent this status code's existence.

The logic goes:
- check if the overall status code is the worst case (`ERR_MULTIPLE_OPERATIONS_FAILED`) -> if true, do not update
- determine the general status code using the status code
- check if the overall status code is the default case (`ORPHANED`) -> if true, update it to the determined general status code.
- finally check the general code with the overall code against a hierarchy, if the general code is higher in the hierarchy than overall code, the general code supersedes it.

---

### Minor changes and fixes
1. All classes except `StatusErrorBatchWith<F>` defaults the overall status code to `ORPHANED`
2. Fixed off by one error inside `StatusErrorBatchWith<F>` during `_failure_count` tracking and usage (finally).
3. Renamed member function and member variables for consistency in naming and intention (I can type fluff too)
4. Reorganized classes to follow "classes with longer names go lower in the file" rule (self made).
5. Added `constexpr` to applicable functions and constructors
6. Removed constructor initialization and switched to inline initialization
7. Added `static_assert` wherever appropriate.
8. Added default constructors (set to `default`) in classes containing custom constructors.

---

This PR doesn't propagate the changes to rest of the files using `RapidResponse.hpp`. The feat branch will propagate these updates as the development progresses. 

Benchmarks reveal similar performance profile as compared to previous internal tests of a simpler implementation of `RapidResponseValue` (now `StatusBatchWith<F1, F2>`).

For instance a sample benchmark over a simple implementation of GET command produces the following numbers:

The older benchmark from almost an year ago, on a simpler implementation of `RapidResponseValue`
```bash
> ./old
2026-05-20T15:05:23+05:30
Running X:\bench\old.exe
Run on (12 X 2611 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1280 KiB (x6)
  L3 Unified 12288 KiB (x1)
------------------------------------------------------------------------------------------------
Benchmark                                      Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------
KeyValueFixture/GET_1_Key                   10.2 ns         10.3 ns     74666667 items_per_second=97.5238M/s
KeyValueFixture/GET_10_Keys                 63.0 ns         62.8 ns     11200000 items_per_second=159.289M/s
```

The latest benchmark over the current implementation
```bash
> ./bench
2026-05-20T15:25:11+05:30
Running X:\bench\cmake-build-release\bench.exe
Run on (12 X 2611 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1280 KiB (x6)
  L3 Unified 12288 KiB (x1)
------------------------------------------------------------------------------------------------
Benchmark                                      Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------
KeyValueFixture/GET_1_KEY                   4.88 ns         4.87 ns    144516129 items_per_second=205.534M/s
KeyValueFixture/B_GET_1_KEY                 10.2 ns         10.0 ns     74666667 items_per_second=99.5556M/s
KeyValueFixture/B_GET_8_KEYS                49.5 ns         48.8 ns     11200000 items_per_second=163.84M/s
KeyValueFixture/B_GET_10_Keys               60.7 ns         57.8 ns     10000000 items_per_second=172.973M/s
KeyValueFixture/B_GET_50_Keys                476 ns          471 ns      1493333 items_per_second=106.193M/s
```

To compare for 10 keys with the old benchmark fairly (which only statically allocated, never expanded to dynamic allocation), I increased the `VALUE_TRACKING_CAPACITY` to 1 more than 10 (i.e. 11), since in the older system entirely allocated on stack by allocating for 32 static entries.
"Why not set it to 10?" Well... idk why but, when I set it to 10, the results were slower (around 71 ns). Maybe the dynamic allocation gets ready when the last entry is added? Maybe something compiler prepares? Flaw in my code logic? Idk, will look into it later, but making it one more than 10, gave me better numbers.

As you can see, the previous `GET_1_Key` (which is basically our `B_GET_1_KEY` but with crazy buffer size) was 10 ns and our `B_GET_1_KEY` is also 10ns. Literally same. `B_GET_10_Keys` and `GET_10_Keys` are also essentially the same at 60 ns. So, the performance profile remains the same, it's just better API.
Though... I guess the older benchmarks are kind of invalid to compare to, since it was a simple and light implementation of `StatusBatchWith<F1, F2>` (previously, `RapidResponseValue`), so you can ignore it.

The new metrics are `GET_1_KEY` (uses `StatusBatchWith`, the light class) and `B_GET_50_Keys` (demonstrates dynamic allocation overhead)

The current benchmarks uses two of the current classes: `StatusWith<F>` and `StatusBatchWith<F1, F2>`.
These classes were used along with a simple implementation of GET declared as follows:
```cpp
// GET_1_KEY
StatusWith<const RapidDataType*> GET_Single(const std::string_view key); 

// B_GET_N_KEYS
StatusBatchWith<std::string_view, const RapidDataType*>GET(const std::span<RapidNode> args);
```

The performance hit for 50 keys is warranted, because dynamic allocation has started, if static allocation was in place it would have been around 300 nanoseconds for 50 keys (calculated based on ns/key from 10 key bench).

> Everything was compiled on `clang` with `-O3` and `-march=native` (release build)

And with `-O0` the following are the results (don't look):
```bash
> ./bench_0
2026-05-20T15:41:59+05:30
Running X:\bench\cmake-build-release\bench_0.exe
Run on (12 X 2611 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1280 KiB (x6)
  L3 Unified 12288 KiB (x1)
------------------------------------------------------------------------------------------------
Benchmark                                      Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------
KeyValueFixture/GET_1_KEY                   53.6 ns         54.7 ns     10000000 items_per_second=18.2857M/s
KeyValueFixture/B_GET_1_KEY                  226 ns          225 ns      2986667 items_per_second=4.44527M/s
KeyValueFixture/B_GET_8_KEYS                 665 ns          663 ns       896000 items_per_second=12.0724M/s
KeyValueFixture/B_GET_10_Keys                773 ns          785 ns       896000 items_per_second=12.7431M/s
KeyValueFixture/B_GET_50_Keys               3956 ns         3924 ns       179200 items_per_second=12.7431M/s

```

Nasty, ain't it?