### PR TITLE
fix: building riri fails on linux systems due to STL disagreements on TC of `std::pair`

### DIFF
--- a/include/riri/RapidResponse.hpp
+++ b/include/riri/RapidResponse.hpp
@@ -205,7 +205,10 @@ namespace RiRi::Response {
          * - `Key2: ERR_KEY_NOT_FOUND`
          * - `Key3: Val3`
          */
-        using EntryType = std::pair<F1, ResultOrStatus>;
+        struct EntryType {
+            F1 target;
+            ResultOrStatus result;
+        };
 
         // Just in case my future self decides to make the EntryType trivially non-copyable.
         static_assert(std::is_trivially_copyable_v<EntryType>, "EntryType must be trivially copyable!!!");

--- a/include/riri/RapidResponse.hpp
+++ b/include/riri/RapidResponse.hpp
@@ -505,7 +505,10 @@ namespace RiRi::Response {
          * - `key3: ERR_KEY_NOT_FOUND`
          * - `key7: ERR_KEY_NOT_FOUND`
          */
-        using ErrorEntryType = std::pair<F, StatusCode>;
+        struct ErrorEntryType {
+            F target;
+            StatusCode code;
+        };
         static_assert(std::is_trivially_destructible_v<ErrorEntryType>, "EntryType must be trivially destructible!!!");
         // Must be trivially destructible
 

--- a/tests/units/response/test_status_batch_with.cpp
+++ b/tests/units/response/test_status_batch_with.cpp
@@ -196,8 +196,8 @@ TEST_SUITE("Rapid Response System") {
             CHECK(response_strv_rdt.totalEntryCount() == 1);
             auto it = response_strv_rdt.begin();
             REQUIRE(it != response_strv_rdt.end());
-            CHECK(it->first == node.key);
-            auto result_strv_rdt = unpack_field(&it->second);
+            CHECK(it->target == node.key);
+            auto result_strv_rdt = unpack_field(&it->result);
             REQUIRE(result_strv_rdt != nullptr);    // IMP
             CHECK(*result_strv_rdt == node.value);
 
@@ -210,10 +210,10 @@ TEST_SUITE("Rapid Response System") {
             CHECK(response_rdt_rdt.totalEntryCount() == 1);
             auto it2 = response_rdt_rdt.begin();
             REQUIRE(it2 != response_rdt_rdt.end());
-            auto target_rdt_rdt = it2->first;
+            auto target_rdt_rdt = it2->target;
             REQUIRE(target_rdt_rdt != nullptr);     // IMP
             CHECK(*target_rdt_rdt == node.value);
-            auto field_rdt_rdt = unpack_field(&it2->second);
+            auto field_rdt_rdt = unpack_field(&it2->result);
             REQUIRE(field_rdt_rdt != nullptr);      // IMP
             CHECK(*field_rdt_rdt == node.value);
         }
@@ -228,8 +228,8 @@ TEST_SUITE("Rapid Response System") {
             CHECK(response_strv_rdt.totalEntryCount() == 1);
             auto it = response_strv_rdt.begin();
             REQUIRE(it != response_strv_rdt.end());
-            CHECK(it->first == node.key);
-            auto code_strv_rdt = unpack_field_code(&it->second);
+            CHECK(it->target == node.key);
+            auto code_strv_rdt = unpack_field_code(&it->result);
             REQUIRE(code_strv_rdt != nullptr);      // IMP
             CHECK(*code_strv_rdt == RiRi::StatusCode::ERR_UNKNOWN);
 
@@ -239,8 +239,8 @@ TEST_SUITE("Rapid Response System") {
             CHECK(response_strv_mono.totalEntryCount() == 1);
             auto it2 = response_strv_mono.begin();
             REQUIRE(it2 != response_strv_mono.end());
-            CHECK(it2->first == node.key);
-            auto code_strv_mono = unpack_field_code(&it2->second);
+            CHECK(it2->target == node.key);
+            auto code_strv_mono = unpack_field_code(&it2->result);
             REQUIRE(code_strv_mono != nullptr);     // IMP
             CHECK(*code_strv_mono == RiRi::StatusCode::ERR_UNKNOWN);
 
@@ -250,10 +250,10 @@ TEST_SUITE("Rapid Response System") {
             CHECK(response_rdt_rdt.totalEntryCount() == 1);
             auto it3 = response_rdt_rdt.begin();
             REQUIRE(it3 != response_rdt_rdt.end());
-            auto target_rdt_rdt = it3->first;
+            auto target_rdt_rdt = it3->target;
             REQUIRE(target_rdt_rdt != nullptr);     // IMP
             CHECK(*target_rdt_rdt == node.value);
-            auto code_rdt_rdt = unpack_field_code(&it3->second);
+            auto code_rdt_rdt = unpack_field_code(&it3->result);
             REQUIRE(code_rdt_rdt != nullptr);       // IMP
             CHECK(*code_rdt_rdt == RiRi::StatusCode::ERR_UNKNOWN);
         }

--- a/tests/units/response/test_status_error_batch_with.cpp
+++ b/tests/units/response/test_status_error_batch_with.cpp
@@ -104,13 +104,13 @@ TEST_SUITE("Rapid Response System") {
             auto it = response.begin(); // this can't be nullptr, unless the
                 // object is somehow corrupted; then you DO deserve getting seg-faulted
 
-            REQUIRE(it->first != nullptr);  // IMP
-            CHECK(*it->first == val_one);
-            CHECK(it->second == RiRi::StatusCode::ERR_UNKNOWN);
+            REQUIRE(it->target != nullptr);  // IMP
+            CHECK(*it->target == val_one);
+            CHECK(it->code == RiRi::StatusCode::ERR_UNKNOWN);
             ++it;
-            REQUIRE(it->first != nullptr);  // IMP
-            CHECK(*it->first == val_two);
-            CHECK(it->second == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
+            REQUIRE(it->target != nullptr);  // IMP
+            CHECK(*it->target == val_two);
+            CHECK(it->code == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
 
             // <std::string_view>
             StatusErrorBatchWith<std::string_view> response_alt;
@@ -119,12 +119,12 @@ TEST_SUITE("Rapid Response System") {
 
             auto it_alt = response_alt.begin();
                 // Again, string_view comparison does not dereference memory
-            CHECK(it_alt->first == "_key1");
-            CHECK(it_alt->second == RiRi::StatusCode::ERR_UNKNOWN);
+            CHECK(it_alt->target == "_key1");
+            CHECK(it_alt->code == RiRi::StatusCode::ERR_UNKNOWN);
             ++it_alt;
                 // same idea here
-            CHECK(it_alt->first == "_key2");
-            CHECK(it_alt->second == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
+            CHECK(it_alt->target == "_key2");
+            CHECK(it_alt->code == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
         }
 
 


### PR DESCRIPTION
Resolves #43

Yeeted `std::pair` entirely from raresy and used simple struct of the same names with `target` and `result`/`code` members.

Structs added:
- `EntryType` - `target`, `result`
- `ErrorEntryType` - `target`, `code`

Also, updated the tests to respect these changes.