### PR TITLE
fix: missing LTO configuration on `windows-latest` with `clang-cl` jobs

### DIFF
--- a/.github/workflows/build_and_test_riri.yaml
+++ b/.github/workflows/build_and_test_riri.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test:
-    name: On ${{ matrix.os }} using ${{ matrix.compiler }} with RIRI_LTO=${{ matrix.lto-config.lto }}, RIRI_LTO_FOR_TESTS=${{ matrix.lto-config.lto-for-tests }}
+    name: ${{ matrix.os }} / ${{ matrix.compiler }} with LTO(RiRi)=${{ matrix.lto-config.lto }}, LTO(Tests)=${{ matrix.lto-config.lto-for-tests }}
     strategy:
       fail-fast: false
       matrix:
@@ -22,7 +22,7 @@ jobs:
           - os: windows-latest
             compiler: g++        # not checking g++ on Windows
           - os: ubuntu-latest
-            compiler: clang-cl  # not checking clang-cl on Linux
+            compiler: clang-cl   # not checking clang-cl on Linux
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build_and_test_riri.yaml
+++ b/.github/workflows/build_and_test_riri.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test:
-    name: ${{ matrix.os }} / ${{ matrix.compiler }} / LTO(RiRi)=${{ matrix.lto-config.lto }} / ${{ matrix.lto-config.lto-for-tests }}
+    name: ${{ matrix.os }} / ${{ matrix.compiler }} / LTO(RiRi)=${{ matrix.lto-config.lto }} / LTO(Tests)=${{ matrix.lto-config.lto-for-tests }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_and_test_riri.yaml
+++ b/.github/workflows/build_and_test_riri.yaml
@@ -22,7 +22,7 @@ jobs:
           - os: windows-latest
             compiler: g++        # not checking g++ on Windows
           - os: ubuntu-latest
-            ccompiler: clang-cl  # not checking clang-cl on Linux
+            compiler: clang-cl  # not checking clang-cl on Linux
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build_and_test_riri.yaml
+++ b/.github/workflows/build_and_test_riri.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test:
-    name: ${{ matrix.os }} / ${{ matrix.compiler }} with LTO(RiRi)=${{ matrix.lto-config.lto }}, LTO(Tests)=${{ matrix.lto-config.lto-for-tests }}
+    name: ${{ matrix.os }} / ${{ matrix.compiler }} / LTO(RiRi)=${{ matrix.lto-config.lto }} / ${{ matrix.lto-config.lto-for-tests }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_and_test_riri.yaml
+++ b/.github/workflows/build_and_test_riri.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install LLVM (Ubuntu)
         if: runner.os == 'Linux'

--- a/.github/workflows/build_and_test_riri.yaml
+++ b/.github/workflows/build_and_test_riri.yaml
@@ -8,21 +8,21 @@ on:
 
 jobs:
   build-and-test:
+    name: On ${{ matrix.os }} using ${{ matrix.compiler }} with RIRI_LTO=${{ matrix.lto-config.lto }}, RIRI_LTO_FOR_TESTS=${{ matrix.lto-config.lto-for-tests }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        compiler: [clang++, g++]
+        compiler: [clang++, g++, clang-cl]
         lto-config:
           - { lto: OFF, lto-for-tests: ON  }   # default (LTO on Test only)
           - { lto: ON,  lto-for-tests: ON  }   # RIRI_LTO=ON (LTO on Test and Library)
           - { lto: OFF, lto-for-tests: OFF }   # RIRI_LTO_FOR_TESTS=OFF (LTO off)
         exclude:
           - os: windows-latest
-            compiler: g++       # not checking g++ on Windows
-        include:
-          - os: windows-latest
-            compiler: clang-cl
+            compiler: g++        # not checking g++ on Windows
+          - os: ubuntu-latest
+            ccompiler: clang-cl  # not checking clang-cl on Linux
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Resolves #48 

Apparently `include` just specifies the exact config, so just `clang-cl` on `windows` won't set up the LTO configs (unless I add three exclude configs).

So, I:
- removed the `include` containing `clang-cl` on `windows-latest`
- added `clang-cl` to the compiler matrix
- added a new setup to `exclude` to exclude the `clang-cl` on `ubuntu-latest` combo.


And renamed the name of the jobs.
And updated `actions/checkout@v4` to `actions/checkout@v5` 