### PR TITLE
build: Add unit testing via `doctests` for Upper Command Layers and Utils 

### DIFF
--- a/include/riri/RapidResponse.hpp
+++ b/include/riri/RapidResponse.hpp
@@ -55,7 +55,11 @@ namespace RiRi::Response {
         // default formality constructor
         constexpr Status() noexcept = default;
         // Explicit constructor to initialize `_status_code` with StatusCode types.
-        explicit Status(StatusCode status_code) noexcept : _status_code(status_code) {}
+        explicit Status(StatusCode status_code) noexcept : _status_code(status_code) {
+            if (static_cast<int16_t>(status_code) >= 400) {  // 400+ is the range of errors
+                ++_failure_count;
+            }
+        }
 
     private:
         /// Represents a single status outcome; either from a single operation
@@ -73,7 +77,7 @@ namespace RiRi::Response {
          */
         constexpr void setCode(const StatusCode status_code) noexcept {
             _status_code = status_code;
-            if (static_cast<int16_t>(status_code) > 400) {  // 400+ is the range of errors
+            if (static_cast<int16_t>(status_code) >= 400) {  // 400+ is the range of errors
                 ++_failure_count;
             }
         }

--- a/include/riri/RapidResponse.hpp
+++ b/include/riri/RapidResponse.hpp
@@ -62,13 +62,28 @@ namespace RiRi::Response {
         /// or is the overall result when no per-operation diagnostics are needed.
         StatusCode _status_code = StatusCode::ORPHANED;
 
+        /// Total failure count
+        int16_t _failure_count = 0;
+
     public:
         /**
          * @brief Setter to set the status code of the response
+         * @note Also updates the count of errors if the status code is an error.
          * @param status_code The status code to be set
          */
         constexpr void setCode(const StatusCode status_code) noexcept {
             _status_code = status_code;
+            if (static_cast<int16_t>(status_code) > 400) {  // 400+ is the range of errors
+                ++_failure_count;
+            }
+        }
+
+        /**
+         * @brief Returns the error count of the response
+         * @return _failure_count
+         */
+        [[nodiscard]] constexpr int16_t errorCount() const noexcept {
+            return _failure_count;
         }
 
         /**

--- a/include/riri/RapidTypes.hpp
+++ b/include/riri/RapidTypes.hpp
@@ -75,6 +75,7 @@ namespace RiRi {
 
         // WARNING CODES (200-299)
         WARN_KEY_STORE_NEARING_CAPACITY = 200,      // COMMAND LEVEL
+        WARN_ZERO_NODES_PROVIDED = 201,             // COMMAND LEVEL
         WARN_RESPONSE_CONTAINS_WARNINGS = 250,      // RESPONSE LEVEL
 
         // We might need warning codes and a lot of them.

--- a/include/riri/utils/Accessors.hpp
+++ b/include/riri/utils/Accessors.hpp
@@ -116,6 +116,7 @@ namespace RiRi::Utils {
             CASE(OK);
             CASE(ORPHANED);
             CASE(WARN_KEY_STORE_NEARING_CAPACITY);
+            CASE(WARN_ZERO_NODES_PROVIDED);
             CASE(WARN_RESPONSE_CONTAINS_WARNINGS);
             CASE(ERR_KEY_STORE_FULL);
             CASE(ERR_UNKNOWN);

--- a/src/commands/delete.cpp
+++ b/src/commands/delete.cpp
@@ -13,9 +13,22 @@ namespace RiRi::Commands {
 
     Response::Status DELETE (std::span<RapidNode> nodes) {
         Response::Status response;
+
+        // I am so sorry.
+        if (nodes.size() == 1) {
+            if (!Internal::deleteKey(nodes[0].key)) {
+                // if deletion failed
+                response.setCode(StatusCode::ERR_KEY_NOT_FOUND);
+                return response;
+            }
+            response.setCode(StatusCode::OK);
+            return response;
+        }
+
         response.setCode(StatusCode::OK);   // set default code
         for (auto& [key, _]: nodes) {
-            if (const bool success = Internal::deleteKey(key); !success) {
+            if (!Internal::deleteKey(key)) {
+                // if deletion failed
                 response.setCode(StatusCode::ERR_SOME_OPERATIONS_FAILED);
             }
         }
@@ -26,7 +39,8 @@ namespace RiRi::Commands {
         // the default code is OK (internal implementation)
         Response::StatusErrorBatchWith<std::string_view> response;
         for (auto& [key, _]: nodes) {
-            if (const bool success = Internal::deleteKey(key); !success) {
+            if (!Internal::deleteKey(key)) {
+                // if deletion failed
                 response.addErrorEntry(key, StatusCode::ERR_KEY_NOT_FOUND);
             }
         }
@@ -37,7 +51,8 @@ namespace RiRi::Commands {
         Response::StatusBatchWith<std::string_view, std::monostate> response;
         response.setCode(StatusCode::OK);   // set default overall code
         for (auto& [key, _]: nodes) {
-            if (const bool success = Internal::deleteKey(key); !success) {
+            if (!Internal::deleteKey(key)) {
+                // if deletion failed
                 response.addStatusEntry(key, StatusCode::ERR_KEY_NOT_FOUND);
             }
         }

--- a/src/commands/delete.cpp
+++ b/src/commands/delete.cpp
@@ -15,6 +15,10 @@ namespace RiRi::Commands {
         Response::Status response;
 
         // I am so sorry.
+        if (nodes.empty()) {
+            response.setCode(StatusCode::WARN_ZERO_NODES_PROVIDED);
+            return response;
+        }
         if (nodes.size() == 1) {
             if (!Internal::deleteKey(nodes[0].key)) {
                 // if deletion failed
@@ -38,6 +42,10 @@ namespace RiRi::Commands {
     Response::StatusErrorBatchWith<std::string_view> DELETE (std::span<RapidNode> nodes, enableErrorBatched) {
         // the default code is OK (internal implementation)
         Response::StatusErrorBatchWith<std::string_view> response;
+        if (nodes.empty()) {
+            response.setCode(StatusCode::WARN_ZERO_NODES_PROVIDED);
+            return response;
+        }     // exit early if empty
         for (auto& [key, _]: nodes) {
             if (!Internal::deleteKey(key)) {
                 // if deletion failed
@@ -49,6 +57,10 @@ namespace RiRi::Commands {
 
     Response::StatusBatchWith<std::string_view, std::monostate> DELETE (std::span<RapidNode> nodes, enableBatched) {
         Response::StatusBatchWith<std::string_view, std::monostate> response;
+        if (nodes.empty()) {
+            response.setCode(StatusCode::WARN_ZERO_NODES_PROVIDED);
+            return response;
+        }
         response.setCode(StatusCode::OK);   // set default overall code
         for (auto& [key, _]: nodes) {
             if (!Internal::deleteKey(key)) {

--- a/src/commands/get.cpp
+++ b/src/commands/get.cpp
@@ -15,9 +15,16 @@ namespace RiRi::Commands {
 
     Response::StatusWith<const RapidDataType*> GET (std::span<RapidNode> node) {
         Response::StatusWith<const RapidDataType*> response;
+        if (node.empty()) {
+            response.setCode(StatusCode::WARN_ZERO_NODES_PROVIDED);
+            return response;
+        }
         if (node.size() != 1) {
             response.setCode(StatusCode::ERR_SINGLE_NODE_EXPECTED);
-            // field stays nullptr (default init)
+            // the field stays nullptr (default init) -> wait! they might dereference it!
+            // wait nvm, it's a const pointer that doesn't save them from dereferencing a nullptr tho!
+            // let's actually test it later.
+            // TODO
             return response;
         }
         auto value = Internal::getValue(node[0].key);
@@ -29,6 +36,10 @@ namespace RiRi::Commands {
 
     Response::StatusBatchWith<std::string_view, const RapidDataType*> GET (std::span<RapidNode> nodes, enableBatched) {
         Response::StatusBatchWith<std::string_view, const RapidDataType *> response;
+        if (nodes.empty()) {
+            response.setCode(StatusCode::WARN_ZERO_NODES_PROVIDED);
+            return response;
+        }   // early exit on empty nodes
         for (auto &[key, _]: nodes) { // _ instead of "value" since we don't care about it
             auto val = Internal::getValue(key);
             val ? response.addResultEntry(key, val):

--- a/src/commands/set.cpp
+++ b/src/commands/set.cpp
@@ -18,9 +18,22 @@ namespace RiRi::Commands {
 
     Response::Status SET (std::span<RapidNode> nodes) {
         Response::Status response;
+
+        // I am so sorry.
+        if (nodes.size() == 1) {
+            if (!Internal::setValue(std::move(nodes[0].key),std::move(nodes[0].value))) {
+                // if insertion failed
+                response.setCode(StatusCode::ERR_KEY_ALREADY_EXISTS);
+                return response;
+            }
+            response.setCode(StatusCode::OK);
+            return response;
+        }
+
         response.setCode(StatusCode::OK);   // set default code
         for (auto&[key, value]: nodes) {
-            if (const bool success = Internal::setValue(std::move(key),std::move(value)); !success) {
+            if (!Internal::setValue(std::move(key),std::move(value))) {
+                // if insertion failed
                 response.setCode(StatusCode::ERR_SOME_OPERATIONS_FAILED);
             }
         }
@@ -31,7 +44,9 @@ namespace RiRi::Commands {
         // the default code is OK (internal implementation)
         Response::StatusErrorBatchWith<std::string_view> response;
         for (auto& [key, value]: nodes) {
-            if (const bool success = Internal::setValue(std::move(key),std::move(value)); !success) {
+            if (!Internal::setValue(std::move(key),std::move(value))) {
+                // if insertion failed
+
                 // try_emplace allows me to do this directly if things go wrong, heh
                 response.addErrorEntry(key, StatusCode::ERR_KEY_ALREADY_EXISTS);
             }
@@ -43,7 +58,8 @@ namespace RiRi::Commands {
         Response::StatusBatchWith<std::string_view, std::monostate> response;
         response.setCode(StatusCode::OK);   // set default overall code
         for (auto& [key, value]: nodes) {
-            if (const bool success = Internal::setValue(std::move(key),std::move(value)); !success) {
+            if (!Internal::setValue(std::move(key),std::move(value))) {
+                // if insertion failed
                 response.addStatusEntry(key, StatusCode::ERR_KEY_ALREADY_EXISTS);
             }
             // we don't need to track success cases, so no need to call `addResultEntry()`

--- a/src/commands/set.cpp
+++ b/src/commands/set.cpp
@@ -20,6 +20,10 @@ namespace RiRi::Commands {
         Response::Status response;
 
         // I am so sorry.
+        if (nodes.empty()) {
+            response.setCode(StatusCode::WARN_ZERO_NODES_PROVIDED);
+            return response;
+        }
         if (nodes.size() == 1) {
             if (!Internal::setValue(std::move(nodes[0].key),std::move(nodes[0].value))) {
                 // if insertion failed
@@ -43,6 +47,10 @@ namespace RiRi::Commands {
     Response::StatusErrorBatchWith<std::string_view> SET (std::span<RapidNode> nodes, enableErrorBatched) {
         // the default code is OK (internal implementation)
         Response::StatusErrorBatchWith<std::string_view> response;
+        if (nodes.empty()) {
+            response.setCode(StatusCode::WARN_ZERO_NODES_PROVIDED);
+            return response;
+        }     // exit early if nodes are empty
         for (auto& [key, value]: nodes) {
             if (!Internal::setValue(std::move(key),std::move(value))) {
                 // if insertion failed
@@ -56,6 +64,10 @@ namespace RiRi::Commands {
 
     Response::StatusBatchWith<std::string_view, std::monostate> SET (std::span<RapidNode> nodes, enableBatched) {
         Response::StatusBatchWith<std::string_view, std::monostate> response;
+        if (nodes.empty()) {
+            response.setCode(StatusCode::WARN_ZERO_NODES_PROVIDED);
+            return response;
+        }
         response.setCode(StatusCode::OK);   // set default overall code
         for (auto& [key, value]: nodes) {
             if (!Internal::setValue(std::move(key),std::move(value))) {

--- a/src/commands/update.cpp
+++ b/src/commands/update.cpp
@@ -15,6 +15,10 @@ namespace RiRi::Commands {
         Response::Status response;
 
         // I am so sorry.
+        if (nodes.empty()) {
+            response.setCode(StatusCode::WARN_ZERO_NODES_PROVIDED);
+            return response;
+        }
         if (nodes.size() == 1) {
             if (!Internal::updateValue(nodes[0].key, std::move(nodes[0].value))) {
                 // if update failed
@@ -38,6 +42,10 @@ namespace RiRi::Commands {
     Response::StatusErrorBatchWith<std::string_view> UPDATE (std::span<RapidNode> nodes, enableErrorBatched) {
         // the default code is OK (internal implementation)
         Response::StatusErrorBatchWith<std::string_view> response;
+        if (nodes.empty()) {
+            response.setCode(StatusCode::WARN_ZERO_NODES_PROVIDED);
+            return response;
+        } // exit early if empty
         for (auto& [key, value]: nodes) {
             if (!Internal::updateValue(key, std::move(value))) {
                 // if update failed
@@ -50,6 +58,10 @@ namespace RiRi::Commands {
 
     Response::StatusBatchWith<std::string_view, std::monostate> UPDATE (std::span<RapidNode> nodes, enableBatched) {
         Response::StatusBatchWith<std::string_view, std::monostate> response;
+        if (nodes.empty()) {
+            response.setCode(StatusCode::WARN_ZERO_NODES_PROVIDED);
+            return response;
+        }
         response.setCode(StatusCode::OK);   // set default overall code
         for (auto& [key, value]: nodes) {
             if (!Internal::updateValue(key, std::move(value))) {

--- a/src/commands/update.cpp
+++ b/src/commands/update.cpp
@@ -13,9 +13,22 @@ namespace RiRi::Commands {
 
     Response::Status UPDATE (std::span<RapidNode> nodes) {
         Response::Status response;
+
+        // I am so sorry.
+        if (nodes.size() == 1) {
+            if (!Internal::updateValue(nodes[0].key, std::move(nodes[0].value))) {
+                // if update failed
+                response.setCode(StatusCode::ERR_KEY_NOT_FOUND);
+                return response;
+            }
+            response.setCode(StatusCode::OK);
+            return response;
+        }
+
         response.setCode(StatusCode::OK);   // set default code
         for (auto& [key, value]: nodes) {
-            if (const bool success = Internal::updateValue(key, std::move(value)); !success) {
+            if (!Internal::updateValue(key, std::move(value))) {
+                // if update failed
                 response.setCode(StatusCode::ERR_SOME_OPERATIONS_FAILED);
             }
         }
@@ -26,9 +39,10 @@ namespace RiRi::Commands {
         // the default code is OK (internal implementation)
         Response::StatusErrorBatchWith<std::string_view> response;
         for (auto& [key, value]: nodes) {
-            if (const bool success = Internal::updateValue(key, std::move(value)); !success) {
-                // we never move or get rid of the provided key, so we just use it
+            if (!Internal::updateValue(key, std::move(value))) {
+                // if update failed
                 response.addErrorEntry(key, StatusCode::ERR_KEY_NOT_FOUND);
+                // we never move or get rid of the provided key, so we just use it
             }
         }
         return response;
@@ -38,7 +52,8 @@ namespace RiRi::Commands {
         Response::StatusBatchWith<std::string_view, std::monostate> response;
         response.setCode(StatusCode::OK);   // set default overall code
         for (auto& [key, value]: nodes) {
-            if (const bool success = Internal::updateValue(key, std::move(value)); !success) {
+            if (!Internal::updateValue(key, std::move(value))) {
+                // if update failed
                 response.addStatusEntry(key, StatusCode::ERR_KEY_NOT_FOUND);
             }
             // we don't need to track success cases, so no need to call `addResultEntry()`

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_executable(RiRi_tests
         test_main.cpp
         units/test_core.cpp
+        units/test_utils.cpp
         units/commands/test_set.cpp
         units/commands/test_get.cpp
         units/commands/test_update.cpp

--- a/tests/units/commands/test_clear.cpp
+++ b/tests/units/commands/test_clear.cpp
@@ -26,10 +26,12 @@ TEST_SUITE("COMMANDS") {
         auto resp = CLEAR();
         REQUIRE(RiRi::Internal::size() == 0);
         CHECK(resp.ok() == true);
+        CHECK(resp.errorCount() == 0);
 
         auto resp_again = CLEAR();    // on empty map, clear does nothing
         REQUIRE(RiRi::Internal::size() == 0);
         CHECK(resp_again.ok() == true);
+        CHECK(resp_again.errorCount() == 0);
     }
 
 }

--- a/tests/units/commands/test_clear.cpp
+++ b/tests/units/commands/test_clear.cpp
@@ -1,0 +1,35 @@
+#include "DataManager.h"
+#include "doctest.h"
+#include "ostream"
+#include "riri/Commands.hpp"
+#include "riri/RapidTypes.hpp"
+
+using namespace RiRi::Commands;
+
+
+TEST_SUITE("COMMANDS") {
+
+    TEST_CASE("CLEAR") {
+
+        // Data
+        RiRi::Internal::clearMap();
+        REQUIRE(RiRi::Internal::size() == 0);
+
+        // we will not use SET for obvious reasons
+        for (int i = 0; i < 100; i++) {
+            RiRi::Internal::setValue(
+                std::move("key"+std::to_string(i)),
+                std::move(RiRi::RapidDataType("RiRi")));
+        }
+        REQUIRE(RiRi::Internal::size() == 100);
+
+        auto resp = CLEAR();
+        REQUIRE(RiRi::Internal::size() == 0);
+        CHECK(resp.ok() == true);
+
+        auto resp_again = CLEAR();    // on empty map, clear does nothing
+        REQUIRE(RiRi::Internal::size() == 0);
+        CHECK(resp_again.ok() == true);
+    }
+
+}

--- a/tests/units/commands/test_clear.cpp
+++ b/tests/units/commands/test_clear.cpp
@@ -1,8 +1,8 @@
 #include "DataManager.h"
 #include "doctest.h"
-#include "ostream"
 #include "riri/Commands.hpp"
 #include "riri/RapidTypes.hpp"
+#include <ostream>
 
 using namespace RiRi::Commands;
 

--- a/tests/units/commands/test_delete.cpp
+++ b/tests/units/commands/test_delete.cpp
@@ -59,11 +59,13 @@ TEST_SUITE("Commands") {
             // (key)
             auto response_f = DELETE("key0");
             CHECK(response_f.code() == RiRi::StatusCode::OK);
+            CHECK(response_f.errorCount() == 0);
             CHECK(RiRi::Internal::size() == 99);
 
             // (span)
             auto response_n = DELETE(nodes_1);
             CHECK(response_n.code() == RiRi::StatusCode::OK);
+            CHECK(response_f.errorCount() == 0);
             CHECK(RiRi::Internal::size() == 98);
 
             // (span, ErrorBatched)
@@ -89,11 +91,13 @@ TEST_SUITE("Commands") {
             // (key)
             auto response_f = DELETE("key101");
             CHECK(response_f.code() == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            CHECK(response_f.errorCount() == 1);
             CHECK(RiRi::Internal::size() == 100);
 
             // (span)
             auto response_n = DELETE(nodes);
             CHECK(response_n.code() == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            CHECK(response_n.errorCount() == 1);
             CHECK(RiRi::Internal::size() == 100);
 
             // (span, ErrorBatched)
@@ -143,6 +147,7 @@ TEST_SUITE("Commands") {
         SUBCASE("DELETE multiple keys; all keys exist") {
             auto response = DELETE(existing_nodes);
             CHECK(response.code() == RiRi::StatusCode::OK);
+            CHECK(response.errorCount() == 0);
             REQUIRE(RiRi::Internal::size() == 0);
             CHECK(RiRi::Internal::getValue("key0") == nullptr);
         }
@@ -151,6 +156,7 @@ TEST_SUITE("Commands") {
         SUBCASE("DELETE multiple keys; no keys exist") {
             auto response = DELETE(new_nodes);
             CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(response.errorCount() == 100);
             REQUIRE(RiRi::Internal::size() == 100);
             CHECK(RiRi::Internal::getValue("key0") != nullptr);
         }
@@ -159,6 +165,7 @@ TEST_SUITE("Commands") {
         SUBCASE("DELETE multiple keys; some exist") {
             auto response = DELETE(mixed_nodes);
             CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(response.errorCount() == 100);
             REQUIRE(RiRi::Internal::size() == 0);
             CHECK(RiRi::Internal::getValue("key0") == nullptr);
         }
@@ -167,6 +174,7 @@ TEST_SUITE("Commands") {
         SUBCASE("DELETE multiple keys; empty span") {
             auto response = DELETE(std::span<RiRi::RapidNode>{}); // NOTE: {} alone is ambiguous
             CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
+            CHECK(response.errorCount() == 0);
             CHECK(RiRi::Internal::size() == 100);
             CHECK(RiRi::Internal::getValue("key0") != nullptr);
         }

--- a/tests/units/commands/test_delete.cpp
+++ b/tests/units/commands/test_delete.cpp
@@ -1,0 +1,306 @@
+#include "DataManager.h"
+#include "doctest.h"
+#include "ostream"
+#include "riri/Commands.hpp"
+#include "riri/RapidTypes.hpp"
+#include "riri/utils/Accessors.hpp"
+
+using namespace RiRi::Commands;
+
+// =============================================== LISTS OF SUBCASES ===================================================
+// +-------------------------------------------------------------+-----------------------------------------------------+
+// |                             SUBCASE                         |                    Overload                         |
+// +-------------------------------------------------------------+-----------------------------------------------------+
+// | 1.  DELETE single key; key exists                           | (key) :: (span) :: (span, enableErrorBatched)       |
+// |                                                             | :: (span, enableBatched)                            |
+// | 2.  DELETE single key; key does not exist                   | (key) :: (span) :: (span, enableErrorBatched)       |
+// |                                                             | :: (span, enableBatched)                            |
+// | 3.  DELETE multiple keys; all keys exist                    | UPDATE(span)                                        |
+// | 4.  DELETE multiple keys; no keys exist                     | UPDATE(span)                                        |
+// | 5.  DELETE multiple keys; some exist                        | UPDATE(span)                                        |
+// | 6.  DELETE multiple keys; empty span                        | UPDATE(span)                                        |
+// | 7.  DELETE multiple keys; all keys exist (ErrorBatched)     | UPDATE(span, enableErrorBatched)                    |
+// | 8.  DELETE multiple keys; no keys exist (ErrorBatched)      | UPDATE(span, enableErrorBatched)                    |
+// | 9.  DELETE multiple keys; some exist (ErrorBatched)         | UPDATE(span, enableErrorBatched)                    |
+// | 10. DELETE multiple keys; empty span (Error Batched)        | UPDATE(span, enableErrorBatched)                    |
+// | 11. DELETE multiple keys; all keys exist (batched)          | UPDATE(span, enableBatched)                         |
+// | 12. DELETE multiple keys; no keys exist (batched)           | UPDATE(span, enableBatched)                         |
+// | 13. DELETE multiple keys; some exist (batched)              | UPDATE(span, enableBatched)                         |
+// | 14. DELETE multiple keys; empty span (batched)              | UPDATE(span, enableBatched)                         |
+// +-------------------------------------------------------------+-----------------------------------------------------+
+
+
+TEST_SUITE("Commands") {
+
+
+    TEST_CASE("DELETE") {
+
+        // Data
+        RiRi::Internal::clearMap();
+        REQUIRE(RiRi::Internal::size() == 0);
+
+        // we will not use SET for obvious reasons
+        for (int i = 0; i < 100; i++) {
+            RiRi::Internal::setValue(
+                std::move("key"+std::to_string(i)),
+                std::move(RiRi::RapidDataType("RiRi")));
+        }
+        REQUIRE(RiRi::Internal::size() == 100);
+
+
+        // 1
+        SUBCASE("DELETE single key; key exists") {
+
+            // Data for span
+            RiRi::RapidNode nodes_1[] {{"key1"}};
+            RiRi::RapidNode nodes_2[] {{"key2"}};
+            RiRi::RapidNode nodes_3[] {{"key3"}};
+
+            // (key)
+            auto response_f = DELETE("key0");
+            CHECK(response_f.code() == RiRi::StatusCode::OK);
+            CHECK(RiRi::Internal::size() == 99);
+
+            // (span)
+            auto response_n = DELETE(nodes_1);
+            CHECK(response_n.code() == RiRi::StatusCode::OK);
+            CHECK(RiRi::Internal::size() == 98);
+
+            // (span, ErrorBatched)
+            auto response_e = DELETE(nodes_2, RiRi::enableErrorBatched{});
+            CHECK(response_e.code() == RiRi::StatusCode::OK);
+            CHECK(RiRi::Internal::size() == 97);
+            CHECK(response_e.begin() == response_e.end());
+            REQUIRE(response_e.totalErrorCount() == 0);
+
+            // (span, Batched)
+            auto response_b = DELETE(nodes_3, RiRi::enableBatched{});
+            CHECK(response_b.code() == RiRi::StatusCode::OK);
+            CHECK(RiRi::Internal::size() == 96);
+            CHECK(response_b.begin() == response_b.end());
+            REQUIRE(response_b.totalEntryCount() == 0);
+        }
+
+        // 2
+        SUBCASE("DELETE single key; key does not exist") {
+            // Data for span
+            RiRi::RapidNode nodes[] {{"key101"}};
+
+            // (key)
+            auto response_f = DELETE("key101");
+            CHECK(response_f.code() == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            CHECK(RiRi::Internal::size() == 100);
+
+            // (span)
+            auto response_n = DELETE(nodes);
+            CHECK(response_n.code() == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            CHECK(RiRi::Internal::size() == 100);
+
+            // (span, ErrorBatched)
+            auto response_e = DELETE(nodes, RiRi::enableErrorBatched{});
+            CHECK(response_e.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(RiRi::Internal::size() == 100);
+            CHECK(response_e.begin() != response_e.end());
+            REQUIRE(response_e.totalErrorCount() == 1);
+            for (auto [key, code]: response_e) {
+                CHECK(key == "key101");
+                CHECK(code == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+
+            // (span, Batched)
+            auto response_b = DELETE(nodes, RiRi::enableBatched{});
+            CHECK(response_b.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(RiRi::Internal::size() == 100);
+            CHECK(response_b.begin() != response_b.end());
+            REQUIRE(response_b.totalEntryCount() == 1);
+            for (auto [key, code]: response_b) {
+                CHECK(key == "key101");
+                REQUIRE(RiRi::Utils::unpack_field_code(&code) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field_code(&code) == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+
+        // Data Setup for the upcoming cases
+        RiRi::RapidNode existing_nodes[100];
+        RiRi::RapidNode new_nodes[100];
+        RiRi::RapidNode mixed_nodes[200];
+
+        for (int i = 0; i < 100; i++) {
+            mixed_nodes[i].key = std::move("key"+std::to_string(i));
+            existing_nodes[i].key = std::move("key"+std::to_string(i));
+            mixed_nodes[i].value = std::move(RiRi::RapidDataType(3.14));
+            existing_nodes[i].value = std::move(RiRi::RapidDataType(3.14));
+
+            new_nodes[i].key = std::move("key"+std::to_string(200+i));
+            mixed_nodes[i+100].key = std::move("key"+std::to_string(200+i));
+            new_nodes[i].value = std::move(RiRi::RapidDataType("raresy"));
+            mixed_nodes[i+100].value = std::move(RiRi::RapidDataType("raresy"));
+        }
+
+
+        // 3
+        SUBCASE("DELETE multiple keys; all keys exist") {
+            auto response = DELETE(existing_nodes);
+            CHECK(response.code() == RiRi::StatusCode::OK);
+            REQUIRE(RiRi::Internal::size() == 0);
+            CHECK(RiRi::Internal::getValue("key0") == nullptr);
+        }
+
+        // 4
+        SUBCASE("DELETE multiple keys; no keys exist") {
+            auto response = DELETE(new_nodes);
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            REQUIRE(RiRi::Internal::size() == 100);
+            CHECK(RiRi::Internal::getValue("key0") != nullptr);
+        }
+
+        // 5
+        SUBCASE("DELETE multiple keys; some exist") {
+            auto response = DELETE(mixed_nodes);
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            REQUIRE(RiRi::Internal::size() == 0);
+            CHECK(RiRi::Internal::getValue("key0") == nullptr);
+        }
+
+        // 6
+        SUBCASE("DELETE multiple keys; empty span") {
+            auto response = DELETE(std::span<RiRi::RapidNode>{}); // NOTE: {} alone is ambiguous
+            CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
+            CHECK(RiRi::Internal::size() == 100);
+            CHECK(RiRi::Internal::getValue("key0") != nullptr);
+        }
+
+        // 7
+        SUBCASE("DELETE multiple keys; all keys exist (ErrorBatched)") {
+            auto response = DELETE(existing_nodes, RiRi::enableErrorBatched{});
+            CHECK(response.code() == RiRi::StatusCode::OK);
+            REQUIRE(RiRi::Internal::size() == 0);
+            CHECK(RiRi::Internal::getValue("key0") == nullptr);
+            CHECK(response.begin() == response.end());
+            REQUIRE(response.totalErrorCount() == 0);
+            for (auto &[key, _] : existing_nodes) {
+                auto val = RiRi::Internal::getValue(key);
+                REQUIRE(val == nullptr);
+            }
+        }
+
+        // 8
+        SUBCASE("DELETE multiple keys; no keys exist (ErrorBatched)") {
+            auto response = DELETE(new_nodes, RiRi::enableErrorBatched{});
+            CHECK(response.code() == RiRi::StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED);
+            REQUIRE(RiRi::Internal::size() == 100);
+            CHECK(RiRi::Internal::getValue("key0") != nullptr);
+            CHECK(response.begin() != response.end());
+            REQUIRE(response.totalErrorCount() == 100);
+            for (auto &[key, _] : new_nodes) {
+                auto val = RiRi::Internal::getValue(key);
+                REQUIRE(val == nullptr);
+            }   // ehhhh, why not
+            auto tracked_size = response.end() - response.begin();
+            CHECK(tracked_size == 8);
+            int i = 0;
+            for (auto [key, code]: response) {
+                CHECK(key == new_nodes[i++].key);
+                CHECK(code == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+        // 9
+        SUBCASE("DELETE multiple keys; some exist (ErrorBatched)") {
+            auto response = DELETE(mixed_nodes, RiRi::enableErrorBatched{});
+            CHECK(response.code() == RiRi::StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED);
+            REQUIRE(RiRi::Internal::size() == 0);
+            CHECK(RiRi::Internal::getValue("key0") == nullptr);
+            CHECK(response.begin() != response.end());
+            REQUIRE(response.totalErrorCount() == 100);
+            for (auto &[key, _] : mixed_nodes) {
+                auto val = RiRi::Internal::getValue(key);
+                REQUIRE(val == nullptr);
+            }
+            auto tracked_size = response.end() - response.begin();
+            CHECK(tracked_size == 8);
+            int i = 100;
+            for (auto [key, code]: response) {
+                CHECK(key == mixed_nodes[i++].key);
+                CHECK(code == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+        // 10
+        SUBCASE("DELETE multiple keys; empty span (Error Batched)") {
+            auto response = DELETE({}, RiRi::enableErrorBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
+            CHECK(response.totalErrorCount() == 0);
+            REQUIRE(response.begin() == response.end());
+        }
+
+        // 11
+        SUBCASE("DELETE multiple keys; all keys exist (batched)") {
+            auto response = DELETE(existing_nodes, RiRi::enableBatched{});
+            CHECK(response.code() == RiRi::StatusCode::OK);
+            REQUIRE(RiRi::Internal::size() == 0);
+            CHECK(RiRi::Internal::getValue("key0") == nullptr);
+            CHECK(response.begin() == response.end());
+            REQUIRE(response.totalEntryCount() == 0);
+            for (auto &[key, _] : existing_nodes) {
+                auto val = RiRi::Internal::getValue(key);
+                REQUIRE(val == nullptr);
+            }
+        }
+
+        // 12
+        SUBCASE("DELETE multiple keys; no keys exist (batched)") {
+            auto response = DELETE(new_nodes, RiRi::enableBatched{});
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            REQUIRE(RiRi::Internal::size() == 100);
+            CHECK(RiRi::Internal::getValue("key0") != nullptr);
+            CHECK(response.begin() != response.end());
+            REQUIRE(response.totalEntryCount() == 100);
+            for (auto &[key, _] : new_nodes) {
+                auto updated_val = RiRi::Internal::getValue(key);
+                REQUIRE(updated_val == nullptr);
+            }
+            auto tracked_size = response.end() - response.begin();
+            CHECK(tracked_size == response.totalEntryCount());
+            int i = 0;
+            for (auto &[key, code] : response) {
+                CHECK(key == new_nodes[i++].key);
+                REQUIRE(RiRi::Utils::unpack_field_code(&code) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field_code(&code) == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+        // 13
+        SUBCASE("DELETE multiple keys; some exist (batched)") {
+            auto response = DELETE(mixed_nodes, RiRi::enableBatched{});
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            REQUIRE(RiRi::Internal::size() == 0);
+            CHECK(RiRi::Internal::getValue("key0") == nullptr);
+            CHECK(response.begin() != response.end());
+            REQUIRE(response.totalEntryCount() == 100);
+            for (auto &[key, _] : mixed_nodes) {
+                auto val = RiRi::Internal::getValue(key);
+                REQUIRE(val == nullptr);
+            }
+            auto tracked_size = response.end() - response.begin();
+            CHECK(tracked_size == response.totalEntryCount());
+            int i = 100;
+            for (auto &[key, code] : response) {
+                CHECK(key == mixed_nodes[i++].key);
+                REQUIRE(RiRi::Utils::unpack_field_code(&code) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field_code(&code) == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+        // 14
+        SUBCASE("DELETE multiple keys; empty span (batched)") {
+            auto response = DELETE({}, RiRi::enableBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
+            CHECK(response.begin() == response.end());
+            CHECK(response.totalEntryCount() == 0);
+        }
+    }
+}

--- a/tests/units/commands/test_delete.cpp
+++ b/tests/units/commands/test_delete.cpp
@@ -1,9 +1,9 @@
 #include "DataManager.h"
 #include "doctest.h"
-#include "ostream"
 #include "riri/Commands.hpp"
 #include "riri/RapidTypes.hpp"
 #include "riri/utils/Accessors.hpp"
+#include <ostream>
 
 using namespace RiRi::Commands;
 

--- a/tests/units/commands/test_delete.cpp
+++ b/tests/units/commands/test_delete.cpp
@@ -15,18 +15,18 @@ using namespace RiRi::Commands;
 // |                                                             | :: (span, enableBatched)                            |
 // | 2.  DELETE single key; key does not exist                   | (key) :: (span) :: (span, enableErrorBatched)       |
 // |                                                             | :: (span, enableBatched)                            |
-// | 3.  DELETE multiple keys; all keys exist                    | UPDATE(span)                                        |
-// | 4.  DELETE multiple keys; no keys exist                     | UPDATE(span)                                        |
-// | 5.  DELETE multiple keys; some exist                        | UPDATE(span)                                        |
-// | 6.  DELETE multiple keys; empty span                        | UPDATE(span)                                        |
-// | 7.  DELETE multiple keys; all keys exist (ErrorBatched)     | UPDATE(span, enableErrorBatched)                    |
-// | 8.  DELETE multiple keys; no keys exist (ErrorBatched)      | UPDATE(span, enableErrorBatched)                    |
-// | 9.  DELETE multiple keys; some exist (ErrorBatched)         | UPDATE(span, enableErrorBatched)                    |
-// | 10. DELETE multiple keys; empty span (Error Batched)        | UPDATE(span, enableErrorBatched)                    |
-// | 11. DELETE multiple keys; all keys exist (batched)          | UPDATE(span, enableBatched)                         |
-// | 12. DELETE multiple keys; no keys exist (batched)           | UPDATE(span, enableBatched)                         |
-// | 13. DELETE multiple keys; some exist (batched)              | UPDATE(span, enableBatched)                         |
-// | 14. DELETE multiple keys; empty span (batched)              | UPDATE(span, enableBatched)                         |
+// | 3.  DELETE multiple keys; all keys exist                    | DELETE(span)                                        |
+// | 4.  DELETE multiple keys; no keys exist                     | DELETE(span)                                        |
+// | 5.  DELETE multiple keys; some exist                        | DELETE(span)                                        |
+// | 6.  DELETE multiple keys; empty span                        | DELETE(span)                                        |
+// | 7.  DELETE multiple keys; all keys exist (ErrorBatched)     | DELETE(span, enableErrorBatched)                    |
+// | 8.  DELETE multiple keys; no keys exist (ErrorBatched)      | DELETE(span, enableErrorBatched)                    |
+// | 9.  DELETE multiple keys; some exist (ErrorBatched)         | DELETE(span, enableErrorBatched)                    |
+// | 10. DELETE multiple keys; empty span (Error Batched)        | DELETE(span, enableErrorBatched)                    |
+// | 11. DELETE multiple keys; all keys exist (batched)          | DELETE(span, enableBatched)                         |
+// | 12. DELETE multiple keys; no keys exist (batched)           | DELETE(span, enableBatched)                         |
+// | 13. DELETE multiple keys; some exist (batched)              | DELETE(span, enableBatched)                         |
+// | 14. DELETE multiple keys; empty span (batched)              | DELETE(span, enableBatched)                         |
 // +-------------------------------------------------------------+-----------------------------------------------------+
 
 

--- a/tests/units/commands/test_get.cpp
+++ b/tests/units/commands/test_get.cpp
@@ -1,0 +1,185 @@
+#include "DataManager.h"
+#include "doctest.h"
+#include "ostream"
+#include "riri/Commands.hpp"
+#include "riri/RapidTypes.hpp"
+#include "riri/utils/Accessors.hpp"
+
+using namespace RiRi::Commands;
+
+// =============================================== LISTS OF SUBCASES ===================================================
+// +-------------------------------------------------------------+-----------------------------------------------------+
+// |                             SUBCASE                         |                    Overload                         |
+// +-------------------------------------------------------------+-----------------------------------------------------+
+// | 1.  GET single key; key exists                              | (key) :: (span) :: (span, enableBatched)            |
+// | 2.  GET single key; key does not exist                      | (key) :: (span) :: (span, enableBatched)
+// | 3.  GET multiple keys; any (span)                           | GET(span)
+// | 4.  GET multiple keys; all keys exist                       | GET(span, enableBatched)                            |
+// | 5.  GET multiple keys; no keys exist                        | GET(span, enableBatched)                            |
+// | 6.  GET multiple keys; some exist                           | GET(span, enableBatched)                            |
+// | 7.  GET multiple keys; empty span                           | GET(span, enableBatched)                            |
+// +-------------------------------------------------------------+-----------------------------------------------------+
+
+
+TEST_SUITE("Commands") {
+    TEST_CASE("GET") {
+
+        // Data
+
+        RiRi::Internal::clearMap();
+        REQUIRE(RiRi::Internal::size() == 0);
+
+        // we will not use SET for obvious reasons
+        for (int i = 0; i < 100; i++) {
+            RiRi::Internal::setValue(
+                std::move("key"+std::to_string(i)),
+                std::move(RiRi::RapidDataType("RiRi")));
+        }
+        REQUIRE(RiRi::Internal::size() == 100);
+
+
+        // 1
+        SUBCASE("GET single key; key exists") {
+            // (key)
+            auto response_f = GET("key0");
+            CHECK(response_f.ok() == true);
+            CHECK(response_f.code() == RiRi::StatusCode::OK);
+            REQUIRE(response_f.field() != nullptr);
+            CHECK(*response_f.field() == RiRi::RapidDataType("RiRi"));
+
+            // (span)
+            RiRi::RapidNode node[] {{"key2"}};
+            auto response_n = GET(node);
+            CHECK(response_n.ok() == true);
+            CHECK(response_n.code() == RiRi::StatusCode::OK);
+
+            // (span, enableBatched)
+            auto response_b = GET(node, RiRi::enableBatched{});
+            CHECK(response_b.ok() == true);
+            CHECK(response_b.code() == RiRi::StatusCode::OK);
+            CHECK(response_b.begin() != response_b.end());
+            CHECK(response_b.totalEntryCount() == 1);
+            for (auto [key, val]: response_b) {
+                CHECK(key == node[0].key);
+                REQUIRE(RiRi::Utils::unpack_field(&val) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field(&val) == RiRi::RapidDataType("RiRi"));
+            }
+        }
+
+        // 2
+        SUBCASE("GET single key; key does not exist") {
+            // (key)
+            auto response_f = GET("key101");
+            CHECK(response_f.ok() == false);
+            CHECK(response_f.code() == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            REQUIRE(response_f.field() == nullptr);
+
+            // (span)
+            RiRi::RapidNode node[] {{"key101"}};
+            auto response_n = GET(node);
+            CHECK(response_n.ok() == false);
+            CHECK(response_n.code() == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+
+            // (span, enableBatched)
+            auto response_b = GET(node, RiRi::enableBatched{});
+            CHECK(response_b.ok() == false);
+            CHECK(response_b.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(response_b.begin() != response_b.end());
+            CHECK(response_b.totalEntryCount() == 1);
+            for (auto [key, code]: response_b) {
+                CHECK(key == node[0].key);
+                REQUIRE(RiRi::Utils::unpack_field_code(&code) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field_code(&code) == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+        // Data Setup for the upcoming cases
+        RiRi::RapidNode existing_nodes[100];
+        RiRi::RapidNode new_nodes[100];
+        RiRi::RapidNode mixed_nodes[200];
+
+        for (int i = 0; i < 100; i++) {
+            mixed_nodes[i].key = std::move("key"+std::to_string(i));
+            existing_nodes[i].key = std::move("key"+std::to_string(i));
+
+            new_nodes[i].key = std::move("key"+std::to_string(200+i));
+            mixed_nodes[i+100].key = std::move("key"+std::to_string(200+i));
+        }
+
+        // 3
+        SUBCASE("GET multiple keys; any (span)") {
+            auto response = GET(mixed_nodes);
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_SINGLE_NODE_EXPECTED);
+            REQUIRE(response.field() == nullptr);
+                // this is a special case, GET with span will only accept single node spans
+                // to get batched, one must explicitly pass those tags, consistent API (not really).
+        }
+
+        // 4
+        SUBCASE("GET multiple keys; all keys exist") {
+            auto response = GET(existing_nodes, RiRi::enableBatched{});
+            CHECK(response.ok() == true);
+            CHECK(response.code() == RiRi::StatusCode::OK);
+            CHECK(response.begin() != response.end());
+            CHECK(response.totalEntryCount() == 100);
+            int i = 0;
+            for (auto [key, val]: response) {
+                CHECK(key == existing_nodes[i++].key);
+                REQUIRE(RiRi::Utils::unpack_field(&val) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field(&val) == RiRi::RapidDataType("RiRi"));
+            }
+        }
+
+        // 5
+        SUBCASE("GET multiple keys; no keys exist") {
+            auto response = GET(new_nodes, RiRi::enableBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(response.begin() != response.end());
+            CHECK(response.totalEntryCount() == 100);
+            int i = 0;
+            for (auto [key, code]: response) {
+                CHECK(key == new_nodes[i++].key);
+                REQUIRE(RiRi::Utils::unpack_field_code(&code) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field_code(&code) == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+        // 6
+        SUBCASE("GET multiple keys; some exist") {
+            auto response = GET(mixed_nodes, RiRi::enableBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(response.begin() != response.end());
+            CHECK(response.totalEntryCount() == 200);
+            auto it = response.begin();
+            for (int i = 0 ; i < 100 ; i++ ) {
+                auto key = it->target;
+                auto val = it->result;
+                CHECK(key == mixed_nodes[i].key);
+                REQUIRE(RiRi::Utils::unpack_field(&val) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field(&val) == RiRi::RapidDataType("RiRi"));
+                it++;
+            }
+            for (int i = 100 ; i < 200 ; i++ ) {
+                auto key = it->target;
+                auto code = it->result;
+                CHECK(key == mixed_nodes[i].key);
+                REQUIRE(RiRi::Utils::unpack_field_code(&code) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field_code(&code) == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+                it++;
+            }
+            CHECK(it == response.end());
+        }
+
+        // 7
+        SUBCASE("GET multiple keys; empty span") {
+            auto response = GET({}, RiRi::enableBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
+            CHECK(response.totalEntryCount() == 0);
+            REQUIRE(response.begin() == response.end());
+        }
+    }
+}

--- a/tests/units/commands/test_get.cpp
+++ b/tests/units/commands/test_get.cpp
@@ -1,9 +1,9 @@
 #include "DataManager.h"
 #include "doctest.h"
-#include "ostream"
 #include "riri/Commands.hpp"
 #include "riri/RapidTypes.hpp"
 #include "riri/utils/Accessors.hpp"
+#include <ostream>
 
 using namespace RiRi::Commands;
 

--- a/tests/units/commands/test_set.cpp
+++ b/tests/units/commands/test_set.cpp
@@ -1,0 +1,365 @@
+#include "DataManager.h"
+#include "doctest.h"
+#include <ostream>
+#include "riri/Commands.hpp"
+#include "riri/RapidTypes.hpp"
+#include "riri/utils/Accessors.hpp"
+#include <array>
+
+using namespace RiRi::Commands;
+
+// =============================================== LISTS OF SUBCASES ===================================================
+// +-------------------------------------------------------------+-----------------------------------------------------+
+// |                             SUBCASE                         |                    Overload                         |
+// +-------------------------------------------------------------+-----------------------------------------------------+
+// | 1.  SET single key; unique key                              | (key, value) :: (span) :: (span, enableErrorBatched)|
+// |                                                             | :: (span, enableBatched)                            |
+// | 2.  SET single key; duplicate key                           | (key, value) :: (span) :: (span, enableErrorBatched)|
+// |                                                             | :: (span, enableBatched)                            |
+// | 3.  SET multiple keys; unique keys                          | SET(span)                                           |
+// | 4.  SET multiple keys; duplicate keys                       | SET(span)                                           |
+// | 5.  SET multiple keys; mixed keys                           | SET(span)                                           |
+// | 6.  SET multiple keys; empty span                           | SET(span)                                           |
+// | 7.  SET multiple keys; unique keys (ErrorBatched)           | SET(span, enableErrorBatched)                       |
+// | 8.  SET multiple keys; duplicate keys (ErrorBatched)        | SET(span, enableErrorBatched)                       |
+// | 9.  SET multiple keys; mixed keys (ErrorBatched)            | SET(span, enableErrorBatched)                       |
+// | 10. SET multiple keys; empty span (Error Batched)           | SET(span, enableErrorBatched)                       |
+// | 11. SET multiple keys; unique keys (batched)                | SET(span, enableBatched)                            |
+// | 12. SET multiple keys; duplicate keys (batched)             | SET(span, enableBatched)                            |
+// | 13. SET multiple keys; mixed keys (batched)                 | SET(span, enableBatched)                            |
+// | 14. SET multiple keys; empty span (batched)                 | SET(span, enableBatched)                            |
+// +-------------------------------------------------------------+-----------------------------------------------------+
+
+// NOTE: WE WILL NOT BE CHECKING FOR BOUNDARY CASES, SINCE TESTS FOR
+//       RAPIDRESPONSE.HPP HAVE ALREADY COVERED IT. WE WILL GO BIG.
+
+
+TEST_SUITE ("Commands") {
+
+    TEST_CASE ("SET") {
+
+        // Clean slate
+        RiRi::Internal::clearMap();
+        REQUIRE (RiRi::Internal::size() == 0);
+
+        // Data
+        for (int i = 0; i < 100; i++) {
+            RiRi::Internal::setValue(
+                std::move("key"+std::to_string(i)),
+                std::move(RiRi::RapidDataType("RiRi")));
+        }   // key0...key99 are already in the map
+            // new values -> "raresy" or 3.14, existing values -> "RiRi"
+
+        // 1
+        SUBCASE ("SET single key; unique key") {
+            // (key, value)
+            auto response_f = SET("key100", "raresy");
+            CHECK(response_f.ok() == true);
+            CHECK(RiRi::Internal::size() == 101);
+            REQUIRE(RiRi::Internal::getValue("key100") != nullptr);
+            CHECK(*RiRi::Internal::getValue("key100") == RiRi::RapidDataType("raresy"));
+
+            // (span)
+            RiRi::RapidNode nodes[] {{"key101", "raresy"}};
+            auto response_n = SET(nodes);
+            CHECK(response_n.ok() == true);
+            CHECK(RiRi::Internal::size() == 102);
+            REQUIRE(RiRi::Internal::getValue("key101") != nullptr);
+            CHECK(*RiRi::Internal::getValue("key101") == RiRi::RapidDataType("raresy"));
+
+            // (span, ErrorBatched)
+            RiRi::RapidNode nodes_2[] {{"key102", "raresy"}};
+            auto response_e = SET(nodes_2, RiRi::enableErrorBatched{});
+            CHECK(response_e.ok() == true);
+            CHECK(RiRi::Internal::size() == 103);
+            REQUIRE(RiRi::Internal::getValue("key102") != nullptr);
+            CHECK(response_e.totalErrorCount() == 0);
+            CHECK(response_e.begin() == response_e.end());
+
+            // (span, Batched)
+            RiRi::RapidNode nodes_3[] {{"key103", "raresy"}};
+            auto response_b = SET(nodes_3, RiRi::enableBatched{});
+            CHECK(response_b.ok() == true);
+            CHECK(RiRi::Internal::size() == 104);
+            REQUIRE(RiRi::Internal::getValue("key103") != nullptr);
+            CHECK(*RiRi::Internal::getValue("key103") == RiRi::RapidDataType("raresy"));
+            CHECK(response_b.totalEntryCount() == 0);
+            CHECK(response_b.begin() == response_b.end());
+        }
+
+        // 2
+        SUBCASE ("SET single key; duplicate key") {
+            // (key, value)
+            auto response_f = SET("key1", "raresy");
+            CHECK(response_f.ok() == false);
+            CHECK(response_f.code() == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
+            CHECK(RiRi::Internal::size() == 100);
+            REQUIRE(RiRi::Internal::getValue("key1") != nullptr);
+            CHECK(*RiRi::Internal::getValue("key1") != RiRi::RapidDataType("raresy"));
+            CHECK(*RiRi::Internal::getValue("key1") == RiRi::RapidDataType("RiRi"));    // original value retained
+
+            // (span)
+            RiRi::RapidNode nodes[] {{"key1", "raresy"}};
+            auto response_n = SET(nodes);
+            CHECK(response_n.ok() == false);
+            CHECK(response_n.code() == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
+            CHECK(RiRi::Internal::size() == 100);
+            REQUIRE(RiRi::Internal::getValue("key1") != nullptr);
+            CHECK(*RiRi::Internal::getValue("key1") != RiRi::RapidDataType("raresy"));
+            CHECK(*RiRi::Internal::getValue("key1") == RiRi::RapidDataType("RiRi"));
+
+            // (span, ErrorBatched)
+            RiRi::RapidNode nodes_2[] {{"key1", "raresy"}};
+            auto response_e = SET(nodes_2, RiRi::enableErrorBatched{});
+            CHECK(response_e.ok() == false);
+            CHECK(RiRi::Internal::size() == 100);
+            REQUIRE(RiRi::Internal::getValue("key1") != nullptr);
+            CHECK(*RiRi::Internal::getValue("key1") != RiRi::RapidDataType("raresy"));
+            CHECK(*RiRi::Internal::getValue("key1") == RiRi::RapidDataType("RiRi"));
+            CHECK(response_e.totalErrorCount() == 1);
+            CHECK(response_e.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(response_e.begin() != response_e.end());
+            for (auto &[key, code]: response_e) {
+                CHECK(key == "key1");
+                CHECK(code == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
+            }
+        }
+
+        // data for upcoming cases
+        std::array<RiRi::RapidNode, 100> unique;
+        std::array<RiRi::RapidNode, 100> duplicate;
+        std::array<RiRi::RapidNode, 200> mixed;
+
+        for (int i = 0; i < 100; i++) {
+            unique[i].key = "key" + std::to_string(100 + i);
+            unique[i].value = RiRi::RapidDataType("raresy");
+            duplicate[i].key = "key" + std::to_string(i);
+            duplicate[i].value = RiRi::RapidDataType("raresy");
+            mixed[i].key = "key" + std::to_string(i);
+            mixed[i].value = RiRi::RapidDataType(3.14);
+            mixed[i+100].key = "key" + std::to_string(100 + i);
+            mixed[i+100].value = RiRi::RapidDataType(3.14);
+        }
+
+        // keeping a copy of the nodes for reference
+        auto unique_ref = unique;
+        auto duplicate_ref = duplicate;
+        auto mixed_ref = mixed;
+            // Why? Because SET moves the data from the nodes.
+            // Usually the workflow would be to make a copy of your
+            // original key-values and then pass them over to RiRi
+
+        // 3
+        SUBCASE ("SET multiple keys; unique keys") {
+            // (span)
+            auto response = SET(unique);
+            CHECK(response.ok() == true);
+            CHECK(RiRi::Internal::size() == 200);
+            for (auto &[key, _] : unique_ref) {
+                    // using unique_ref instead of unique (unique is now empty)
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType("raresy"));
+            }
+        }
+
+        // 4
+        SUBCASE ("SET multiple keys; duplicate keys") {
+            // (span)
+            auto response = SET(duplicate);
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(RiRi::Internal::size() == 100);
+            for (auto &[key, _] : duplicate_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) != RiRi::RapidDataType("raresy"));
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType("RiRi"));
+            }
+        }
+
+        // 5
+        SUBCASE ("SET multiple keys; mixed keys") {
+            // (span)
+            auto response = SET(mixed);
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(RiRi::Internal::size() == 200);
+            for (auto &[key, _] : unique_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType(3.14));
+            }
+            for (auto &[key, _] : duplicate_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType("RiRi"));
+            }
+            // we are using unique_ref and duplicate_ref, since mixed contains all the keys
+            // present in these, purely for bifurcation purpose.
+        }
+
+        // 6
+        SUBCASE ("SET multiple keys; empty span") {
+            // (span)
+            auto response = SET({});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
+            CHECK(RiRi::Internal::size() == 100);
+            for (auto &[key, _] : duplicate_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType("RiRi"));
+                    // ensuring that no data got touched.
+            }
+        }
+
+        // 7
+        SUBCASE ("SET multiple keys; unique keys (ErrorBatched)") {
+            // (span, ErrorBatched)
+            auto response = SET(unique, RiRi::enableErrorBatched{});
+            CHECK(response.ok() == true);
+            CHECK(RiRi::Internal::size() == 200);
+            CHECK(response.totalErrorCount() == 0);
+            CHECK(response.begin() == response.end());
+            for (auto &[key, _] : unique_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType("raresy"));
+            }
+            CHECK(response.end() - response.begin() == 0);  // ehhh... redundant, I know.
+        }
+
+        // 8
+        SUBCASE ("SET multiple keys; duplicate keys (ErrorBatched)") {
+            // (span, ErrorBatched)
+            auto response = SET(duplicate, RiRi::enableErrorBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED);
+            CHECK(RiRi::Internal::size() == 100);
+            CHECK(response.totalErrorCount() == 100);
+            CHECK(response.begin() != response.end());
+            for (auto &[key, _] : duplicate_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) != RiRi::RapidDataType("raresy"));
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType("RiRi"));
+            }
+            int i = 0;
+            for (auto &[key, code] : response) {
+                CHECK(key == duplicate_ref[i++].key);
+                CHECK(code == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
+            }
+            CHECK(response.end() - response.begin() == 8);
+            CHECK(i == 8);  // 8 entries + 1 (i++)
+        }
+
+        // 9
+        SUBCASE ("SET multiple keys; mixed keys (ErrorBatched)") {
+            // (span, ErrorBatched)
+            auto response = SET(mixed, RiRi::enableErrorBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED);
+            CHECK(RiRi::Internal::size() == 200);
+            CHECK(response.totalErrorCount() == 100);
+            CHECK(response.begin() != response.end());
+            for (auto &[key, _] : unique_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType(3.14));
+            }
+            for (auto &[key, _] : duplicate_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType("RiRi"));
+            }
+            int i = 0;
+            for (auto &[key, code] : response) {
+                CHECK(key == mixed_ref[i++].key);   // initial 100 keys of mixed are same as duplicate
+            }
+            CHECK(response.end() - response.begin() == 8);
+            CHECK(i == 8);  // 0...7 entries + 1 (i++)
+        }
+
+        // 10
+        SUBCASE ("SET multiple keys; empty span (ErrorBatched)") {
+            // (span, ErrorBatched)
+            auto response = SET({}, RiRi::enableErrorBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
+            CHECK(RiRi::Internal::size() == 100);
+            CHECK(response.totalErrorCount() == 0);
+            CHECK(response.begin() == response.end());
+        }
+
+        // 11
+        SUBCASE ("SET multiple keys; unique keys (Batched)") {
+            // (span, Batched)
+            auto response = SET(unique, RiRi::enableBatched{});
+            CHECK(response.ok() == true);
+            CHECK(RiRi::Internal::size() == 200);
+            CHECK(response.totalEntryCount() == 0);
+            CHECK(response.begin() == response.end());
+            for (auto &[key, _] : unique_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType("raresy"));
+            }
+            CHECK(response.end() - response.begin() == 0);
+        }
+
+        // 12
+        SUBCASE ("SET multiple keys; duplicate keys (Batched)") {
+            // (span, Batched)
+            auto response = SET(duplicate, RiRi::enableBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(RiRi::Internal::size() == 100);
+            CHECK(response.totalEntryCount() == 100);
+            CHECK(response.begin() != response.end());
+            for (auto &[key, _] : duplicate_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) != RiRi::RapidDataType("raresy"));
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType("RiRi"));
+            }
+            int i = 0;
+            for (auto &[key, code] : response) {
+                CHECK(key == duplicate_ref[i++].key);
+                REQUIRE(RiRi::Utils::unpack_field_code(&code) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field_code(&code) == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
+            }
+            CHECK(response.end() - response.begin() == 100);
+            CHECK(i == 100); // 0...99 + 1
+
+        }
+
+        // 13
+        SUBCASE ("SET multiple keys; mixed keys (Batched)") {
+            // (span, Batched)
+            auto response = SET(mixed, RiRi::enableBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(RiRi::Internal::size() == 200);
+            CHECK(response.totalEntryCount() == 100);
+            CHECK(response.begin() != response.end());
+            for (auto &[key, _] : unique_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType(3.14));
+            }
+            for (auto &[key, _] : duplicate_ref) {
+                REQUIRE(RiRi::Internal::getValue(key) != nullptr);
+                CHECK(*RiRi::Internal::getValue(key) == RiRi::RapidDataType("RiRi"));
+            }
+            int i = 0;
+            for (auto &[key, code] : response) {
+                CHECK(key == mixed_ref[i++].key);
+                REQUIRE(RiRi::Utils::unpack_field_code(&code) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field_code(&code) == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
+            }
+            CHECK(response.end() - response.begin() == 100);
+            CHECK(i == 100); // 0...99 + 1
+        }
+
+        // 14
+        SUBCASE ("SET multiple keys; empty span (Batched)") {
+            // (span, Batched)
+            auto response = SET({}, RiRi::enableBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
+            CHECK(RiRi::Internal::size() == 100);
+            CHECK(response.totalEntryCount() == 0);
+            CHECK(response.begin() == response.end());
+        }
+    }
+
+}

--- a/tests/units/commands/test_set.cpp
+++ b/tests/units/commands/test_set.cpp
@@ -1,10 +1,10 @@
 #include "DataManager.h"
 #include "doctest.h"
-#include <ostream>
 #include "riri/Commands.hpp"
 #include "riri/RapidTypes.hpp"
 #include "riri/utils/Accessors.hpp"
 #include <array>
+#include <ostream>
 
 using namespace RiRi::Commands;
 

--- a/tests/units/commands/test_set.cpp
+++ b/tests/units/commands/test_set.cpp
@@ -55,6 +55,7 @@ TEST_SUITE ("Commands") {
             // (key, value)
             auto response_f = SET("key100", "raresy");
             CHECK(response_f.ok() == true);
+            CHECK(response_f.errorCount() == 0);
             CHECK(RiRi::Internal::size() == 101);
             REQUIRE(RiRi::Internal::getValue("key100") != nullptr);
             CHECK(*RiRi::Internal::getValue("key100") == RiRi::RapidDataType("raresy"));
@@ -63,6 +64,7 @@ TEST_SUITE ("Commands") {
             RiRi::RapidNode nodes[] {{"key101", "raresy"}};
             auto response_n = SET(nodes);
             CHECK(response_n.ok() == true);
+            CHECK(response_n.errorCount() == 0);
             CHECK(RiRi::Internal::size() == 102);
             REQUIRE(RiRi::Internal::getValue("key101") != nullptr);
             CHECK(*RiRi::Internal::getValue("key101") == RiRi::RapidDataType("raresy"));
@@ -93,6 +95,7 @@ TEST_SUITE ("Commands") {
             auto response_f = SET("key1", "raresy");
             CHECK(response_f.ok() == false);
             CHECK(response_f.code() == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
+            CHECK(response_f.errorCount() == 1);
             CHECK(RiRi::Internal::size() == 100);
             REQUIRE(RiRi::Internal::getValue("key1") != nullptr);
             CHECK(*RiRi::Internal::getValue("key1") != RiRi::RapidDataType("raresy"));
@@ -102,6 +105,7 @@ TEST_SUITE ("Commands") {
             RiRi::RapidNode nodes[] {{"key1", "raresy"}};
             auto response_n = SET(nodes);
             CHECK(response_n.ok() == false);
+            CHECK(response_n.errorCount() == 1);
             CHECK(response_n.code() == RiRi::StatusCode::ERR_KEY_ALREADY_EXISTS);
             CHECK(RiRi::Internal::size() == 100);
             REQUIRE(RiRi::Internal::getValue("key1") != nullptr);
@@ -154,6 +158,7 @@ TEST_SUITE ("Commands") {
             // (span)
             auto response = SET(unique);
             CHECK(response.ok() == true);
+            CHECK(response.errorCount() == 0);
             CHECK(RiRi::Internal::size() == 200);
             for (auto &[key, _] : unique_ref) {
                     // using unique_ref instead of unique (unique is now empty)
@@ -168,6 +173,7 @@ TEST_SUITE ("Commands") {
             auto response = SET(duplicate);
             CHECK(response.ok() == false);
             CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(response.errorCount() == 100);
             CHECK(RiRi::Internal::size() == 100);
             for (auto &[key, _] : duplicate_ref) {
                 REQUIRE(RiRi::Internal::getValue(key) != nullptr);
@@ -181,6 +187,7 @@ TEST_SUITE ("Commands") {
             // (span)
             auto response = SET(mixed);
             CHECK(response.ok() == false);
+            CHECK(response.errorCount() == 100);
             CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
             CHECK(RiRi::Internal::size() == 200);
             for (auto &[key, _] : unique_ref) {
@@ -200,6 +207,7 @@ TEST_SUITE ("Commands") {
             // (span)
             auto response = SET({});
             CHECK(response.ok() == false);
+            CHECK(response.errorCount() == 0);
             CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
             CHECK(RiRi::Internal::size() == 100);
             for (auto &[key, _] : duplicate_ref) {

--- a/tests/units/commands/test_update.cpp
+++ b/tests/units/commands/test_update.cpp
@@ -60,6 +60,7 @@ TEST_SUITE("Commands") {
             // (key, value)
             auto response_f = UPDATE("key1", 3.14);
             CHECK(response_f.ok() == true);
+            CHECK(response_f.errorCount() == 0);
             auto updated_val = RiRi::Internal::getValue("key1");
             REQUIRE(updated_val != nullptr);
             CHECK(*updated_val == RiRi::RapidDataType(3.14));
@@ -67,6 +68,7 @@ TEST_SUITE("Commands") {
             // (span)
             auto response_n = UPDATE(nodes_1);
             CHECK(response_n.ok() == true);
+            CHECK(response_n.errorCount() == 0);
             auto updated_val2 = RiRi::Internal::getValue("key2");
             REQUIRE(updated_val2 != nullptr);
             CHECK(*updated_val2 == RiRi::RapidDataType("raresy"));
@@ -101,6 +103,7 @@ TEST_SUITE("Commands") {
             // (key, value)
             auto response_f = UPDATE("key101", 3.14);
             CHECK(response_f.ok() == false);
+            CHECK(response_f.errorCount() == 1);
             auto updated_val = RiRi::Internal::getValue("key101");
             CHECK(updated_val == nullptr);
             CHECK(response_f.code() == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
@@ -108,6 +111,7 @@ TEST_SUITE("Commands") {
             // (span)
             auto response_n = UPDATE(nodes);
             CHECK(response_n.ok() == false);
+            CHECK(response_n.errorCount() == 1);
             auto updated_val2 = RiRi::Internal::getValue("key101");
             CHECK(response_n.errorCount() == 1);
             CHECK(updated_val2 == nullptr);

--- a/tests/units/commands/test_update.cpp
+++ b/tests/units/commands/test_update.cpp
@@ -1,0 +1,359 @@
+#include "DataManager.h"
+#include "doctest.h"
+#include "ostream"
+#include "riri/Commands.hpp"
+#include "riri/RapidTypes.hpp"
+#include "riri/utils/Accessors.hpp"
+
+using namespace RiRi::Commands;
+
+// =============================================== LISTS OF SUBCASES ===================================================
+// +-------------------------------------------------------------+-----------------------------------------------------+
+// |                             SUBCASE                         |                    Overload                         |
+// +-------------------------------------------------------------+-----------------------------------------------------+
+// | 1.  UPDATE single key; key exists                           | (key, value) :: (span) :: (span, enableErrorBatched)|
+// |                                                             | :: (span, enableBatched)                            |
+// | 2.  UPDATE single key; key does not exist                   | (key, value) :: (span) :: (span, enableErrorBatched)|
+// |                                                             | :: (span, enableBatched)                            |
+// | 3.  UPDATE multiple keys; all keys exist                    | UPDATE(span)                                        |
+// | 4.  UPDATE multiple keys; no keys exist                     | UPDATE(span)                                        |
+// | 5.  UPDATE multiple keys; some exist                        | UPDATE(span)                                        |
+// | 6.  UPDATE multiple keys; empty span                        | UPDATE(span)                                        |
+// | 7.  UPDATE multiple keys; all keys exist (ErrorBatched)     | UPDATE(span, enableErrorBatched)                    |
+// | 8.  UPDATE multiple keys; no keys exist (ErrorBatched)      | UPDATE(span, enableErrorBatched)                    |
+// | 9.  UPDATE multiple keys; some exist (ErrorBatched)         | UPDATE(span, enableErrorBatched)                    |
+// | 10. UPDATE multiple keys; empty span (Error Batched)        | UPDATE(span, enableErrorBatched)                    |
+// | 11. UPDATE multiple keys; all keys exist (batched)          | UPDATE(span, enableBatched)                         |
+// | 12. UPDATE multiple keys; no keys exist (batched)           | UPDATE(span, enableBatched)                         |
+// | 13. UPDATE multiple keys; some exist (batched)              | UPDATE(span, enableBatched)                         |
+// | 14. UPDATE multiple keys; empty span (batched)              | UPDATE(span, enableBatched)                         |
+// +-------------------------------------------------------------+-----------------------------------------------------+
+
+// NOTE: WE WILL NOT BE CHECKING FOR BOUNDARY CASES, SINCE TESTS FOR
+//       RAPIDRESPONSE.HPP HAVE ALREADY COVERED IT. WE WILL GO BIG.
+
+TEST_SUITE("Commands") {
+
+    TEST_CASE("UPDATE") {
+
+        // Data
+
+        RiRi::Internal::clearMap();
+        REQUIRE(RiRi::Internal::size() == 0);
+
+        // we will not use SET for obvious reasons
+        for (int i = 0; i < 100; i++) {
+            RiRi::Internal::setValue(
+                std::move("key"+std::to_string(i)),
+                std::move(RiRi::RapidDataType("RiRi")));
+        }
+        REQUIRE(RiRi::Internal::size() == 100);
+
+
+        // 1
+        SUBCASE("Update single key; key exists") {
+            // Data for Node
+            RiRi::RapidNode nodes_1[] {{"key2", RiRi::RapidDataType("raresy")}};
+            RiRi::RapidNode nodes_2[] {{"key3", RiRi::RapidDataType("ad4rsh2701")}};
+            RiRi::RapidNode nodes_3[] {{"key4", RiRi::RapidDataType("ShadowsLure")}};
+
+            // (key, value)
+            auto response_f = UPDATE("key1", 3.14);
+            CHECK(response_f.ok() == true);
+            auto updated_val = RiRi::Internal::getValue("key1");
+            REQUIRE(updated_val != nullptr);
+            CHECK(*updated_val == RiRi::RapidDataType(3.14));
+
+            // (span)
+            auto response_n = UPDATE(nodes_1);
+            CHECK(response_n.ok() == true);
+            auto updated_val2 = RiRi::Internal::getValue("key2");
+            REQUIRE(updated_val2 != nullptr);
+            CHECK(*updated_val2 == RiRi::RapidDataType("raresy"));
+                // we will not and CANNOT use nodes[0].value to check!
+                // once a node is used, do not rely on the data
+                // present in it!!! It may have been moved!!
+
+            // (span, errorBatched)
+            auto response_e = UPDATE(nodes_2, RiRi::enableErrorBatched{});
+            CHECK(response_e.ok() == true);
+            auto updated_val3 = RiRi::Internal::getValue("key3");
+            REQUIRE(updated_val3 != nullptr);
+            CHECK(*updated_val3 == RiRi::RapidDataType("ad4rsh2701"));
+            CHECK(response_e.totalErrorCount() == 0);
+            CHECK(response_e.begin() == response_e.end());
+
+            // (span, Batched)
+            auto response_b = UPDATE(nodes_3, RiRi::enableBatched{});
+            CHECK(response_b.ok() == true);
+            auto updated_val4 = RiRi::Internal::getValue("key4");
+            REQUIRE(updated_val4 != nullptr);
+            CHECK(*updated_val4 == RiRi::RapidDataType("ShadowsLure"));
+            CHECK(response_b.totalEntryCount() == 0);
+            CHECK(response_b.begin() == response_b.end());
+        }
+
+        // 2
+        SUBCASE("Update single key; key does not exist") {
+            // Data for Node
+            RiRi::RapidNode nodes[] {{"key101", RiRi::RapidDataType("raresy")}};
+
+            // (key, value)
+            auto response_f = UPDATE("key101", 3.14);
+            CHECK(response_f.ok() == false);
+            auto updated_val = RiRi::Internal::getValue("key101");
+            CHECK(updated_val == nullptr);
+            CHECK(response_f.code() == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+
+            // (span)
+            auto response_n = UPDATE(nodes);
+            CHECK(response_n.ok() == false);
+            auto updated_val2 = RiRi::Internal::getValue("key101");
+            CHECK(response_n.errorCount() == 1);
+            CHECK(updated_val2 == nullptr);
+            CHECK(response_n.code() == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+
+            // (span, errorBatched)
+            auto response_e = UPDATE(nodes, RiRi::enableErrorBatched{});
+            CHECK(response_e.ok() == false);
+            auto updated_val3 = RiRi::Internal::getValue("key101");
+            CHECK(response_e.totalErrorCount() == 1);
+            CHECK(updated_val3 == nullptr);
+            CHECK(response_e.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            for (const auto& [target, code] : response_e) {
+                CHECK(target == "key101");
+                CHECK(code == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+
+            // (span, Batched)
+            auto response_b = UPDATE(nodes, RiRi::enableBatched{});
+            CHECK(response_b.ok() == false);
+            auto updated_val4 = RiRi::Internal::getValue("key101");
+            CHECK(response_b.totalEntryCount() == 1);
+            CHECK(updated_val4 == nullptr);
+            CHECK(response_b.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            for (const auto& [target, field] : response_b) {
+                CHECK(target == "key101");
+                auto field_code = RiRi::Utils::unpack_field_code(&field);
+                REQUIRE(field_code != nullptr);
+                CHECK(*field_code == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+        // Data Setup for the upcoming cases
+        RiRi::RapidNode existing_nodes[100];
+        RiRi::RapidNode new_nodes[100];
+        RiRi::RapidNode mixed_nodes[200];
+
+        for (int i = 0; i < 100; i++) {
+            mixed_nodes[i].key = std::move("key"+std::to_string(i));
+            existing_nodes[i].key = std::move("key"+std::to_string(i));
+            mixed_nodes[i].value = std::move(RiRi::RapidDataType(3.14));
+            existing_nodes[i].value = std::move(RiRi::RapidDataType(3.14));
+
+            new_nodes[i].key = std::move("key"+std::to_string(200+i));
+            mixed_nodes[i+100].key = std::move("key"+std::to_string(200+i));
+            new_nodes[i].value = std::move(RiRi::RapidDataType("raresy"));
+            mixed_nodes[i+100].value = std::move(RiRi::RapidDataType("raresy"));
+        }
+
+
+        // 3
+        SUBCASE("Update multiple keys; all keys exist") {
+            // (span)
+            auto response = UPDATE(existing_nodes);
+            CHECK(response.ok() == true);
+            CHECK(response.errorCount() == 0);
+            REQUIRE(existing_nodes[0].key == "key0");
+            for (auto &[key, _] : existing_nodes) {
+                auto updated_val = RiRi::Internal::getValue(key);
+                REQUIRE(updated_val != nullptr);
+                CHECK(*updated_val == RiRi::RapidDataType(3.14));
+            }
+        }
+
+        // 4
+        SUBCASE("Update multiple keys; no keys exist") {
+            // (span)
+            auto response = UPDATE(new_nodes);
+            CHECK(response.ok() == false);
+            CHECK(response.errorCount() == 100);
+            for (auto &[key, _] : new_nodes) {
+                auto updated_val = RiRi::Internal::getValue(key);
+                CHECK(updated_val == nullptr);
+            }
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+                // SOME OPS FAILED doesn't make sense for ALL OPS FAILED, just noting
+        }
+
+        // 5
+        SUBCASE("Update multiple keys; some exist") {
+            // (span)
+            auto response = UPDATE(mixed_nodes);
+            CHECK(response.ok() == false);
+            CHECK(response.errorCount() == 100);
+            REQUIRE(mixed_nodes[0].key == "key0");
+            for (int i = 0; i < 100; i++) {
+                auto updated_val = RiRi::Internal::getValue(mixed_nodes[i].key);
+                REQUIRE(updated_val != nullptr);
+                CHECK(*updated_val == RiRi::RapidDataType(3.14));
+            }
+            for (int i = 100; i < 200; i++) {
+                auto updated_val = RiRi::Internal::getValue(mixed_nodes[i].key);
+                CHECK(updated_val == nullptr);
+            }
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+        }
+
+        // 6
+        SUBCASE("Update multiple keys; empty span") {
+            auto response = UPDATE({});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
+            CHECK(response.errorCount() == 0);
+            // OKAY PAUSE. This shouldn't be like this.
+        }
+
+        // 7
+        SUBCASE("Update multiple keys; all keys exist (ErrorBatched)") {
+            auto response = UPDATE(existing_nodes, RiRi::enableErrorBatched{});
+            CHECK(response.ok() == true);
+            CHECK(response.code() == RiRi::StatusCode::OK);
+            CHECK(response.totalErrorCount() == 0);
+            REQUIRE(existing_nodes[0].key == "key0");
+            for (auto &[key, _] : existing_nodes) {
+                auto updated_val = RiRi::Internal::getValue(key);
+                REQUIRE(updated_val != nullptr);
+                CHECK(*updated_val == RiRi::RapidDataType(3.14));
+            }
+            REQUIRE(response.begin() == response.end());
+        }
+
+        // 8
+        SUBCASE("Update multiple keys; no keys exist (ErrorBatched)") {
+            auto response = UPDATE(new_nodes, RiRi::enableErrorBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED);
+            CHECK(response.totalErrorCount() == 100);
+            for (auto &[key, _] : new_nodes) {
+                auto updated_val = RiRi::Internal::getValue(key);
+                REQUIRE(updated_val == nullptr);
+            }
+            REQUIRE(response.begin() != response.end());
+            auto tracked_size = response.end() - response.begin();
+            CHECK(tracked_size == 8);
+            int i = 0;
+            for (auto &[key, code] : response) {
+                CHECK(key == new_nodes[i++].key);
+                CHECK(code == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+        // 9
+        SUBCASE("Update multiple keys; some exist (ErrorBatched)") {
+            auto response = UPDATE(mixed_nodes, RiRi::enableErrorBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_MULTIPLE_OPERATIONS_FAILED);
+            CHECK(response.totalErrorCount() == 100);
+            REQUIRE(mixed_nodes[0].key == "key0");
+            for (int i = 0; i < 100; i++) {
+                auto updated_val = RiRi::Internal::getValue(mixed_nodes[i].key);
+                REQUIRE(updated_val != nullptr);
+                CHECK(*updated_val == RiRi::RapidDataType(3.14));
+            }
+            for (int i = 100; i < 200; i++) {
+                auto updated_val = RiRi::Internal::getValue(mixed_nodes[i].key);
+                REQUIRE(updated_val == nullptr);
+            }
+            REQUIRE(response.begin() != response.end());
+            auto tracked_size = response.end() - response.begin();
+            CHECK(tracked_size == 8);
+            int i = 100;
+            for (auto &[key, code] : response) {
+                CHECK(key == mixed_nodes[i++].key);
+                CHECK(code == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+        // 10
+        SUBCASE("Update multiple keys; empty span") {
+            auto response = UPDATE({}, RiRi::enableErrorBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
+            CHECK(response.totalErrorCount() == 0);
+            REQUIRE(response.begin() == response.end());
+        }
+
+        // 11
+        SUBCASE("Update multiple keys; all keys exist (batched)") {
+            auto response = UPDATE(existing_nodes, RiRi::enableBatched{});
+            CHECK(response.ok() == true);
+            CHECK(response.code() == RiRi::StatusCode::OK);
+            CHECK(response.totalEntryCount() == 0);
+            REQUIRE(existing_nodes[0].key == "key0");
+            for (auto &[key, _] : existing_nodes) {
+                auto updated_val = RiRi::Internal::getValue(key);
+                REQUIRE(updated_val != nullptr);
+                CHECK(*updated_val == RiRi::RapidDataType(3.14));
+            }
+            REQUIRE(response.begin() == response.end());
+        }
+
+        // 12
+        SUBCASE("Update multiple keys; no keys exist (batched)") {
+            auto response = UPDATE(new_nodes, RiRi::enableBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(response.totalEntryCount() == 100);
+            for (auto &[key, _] : new_nodes) {
+                auto updated_val = RiRi::Internal::getValue(key);
+                REQUIRE(updated_val == nullptr);
+            }
+            REQUIRE(response.begin() != response.end());
+            auto tracked_size = response.end() - response.begin();
+            CHECK(tracked_size == response.totalEntryCount());
+            int i = 0;
+            for (auto &[key, code] : response) {
+                CHECK(key == new_nodes[i++].key);
+                REQUIRE(RiRi::Utils::unpack_field_code(&code) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field_code(&code) == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+        // 13
+        SUBCASE("Update multiple keys; some exist (batched)") {
+            auto response = UPDATE(mixed_nodes, RiRi::enableBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::ERR_SOME_OPERATIONS_FAILED);
+            CHECK(response.totalEntryCount() == 100);
+            REQUIRE(mixed_nodes[0].key == "key0");
+            for (int i = 0; i < 100; i++) {
+                auto updated_val = RiRi::Internal::getValue(mixed_nodes[i].key);
+                REQUIRE(updated_val != nullptr);
+                CHECK(*updated_val == RiRi::RapidDataType(3.14));
+            }
+            for (int i = 100; i < 200; i++) {
+                auto updated_val = RiRi::Internal::getValue(mixed_nodes[i].key);
+                REQUIRE(updated_val == nullptr);
+            }
+            REQUIRE(response.begin() != response.end());
+            auto tracked_size = response.end() - response.begin();
+            CHECK(tracked_size == response.totalEntryCount());
+            int i = 100;
+            for (auto &[key, code] : response) {
+                CHECK(key == mixed_nodes[i++].key);
+                REQUIRE(RiRi::Utils::unpack_field_code(&code) != nullptr);
+                CHECK(*RiRi::Utils::unpack_field_code(&code) == RiRi::StatusCode::ERR_KEY_NOT_FOUND);
+            }
+        }
+
+        // 14
+        SUBCASE("Update multiple keys; empty span (batched)") {
+            auto response = UPDATE({}, RiRi::enableBatched{});
+            CHECK(response.ok() == false);
+            CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
+            CHECK(response.totalEntryCount() == 0);
+            REQUIRE(response.begin() == response.end());
+        }
+    }
+}

--- a/tests/units/commands/test_update.cpp
+++ b/tests/units/commands/test_update.cpp
@@ -1,9 +1,9 @@
 #include "DataManager.h"
 #include "doctest.h"
-#include "ostream"
 #include "riri/Commands.hpp"
 #include "riri/RapidTypes.hpp"
 #include "riri/utils/Accessors.hpp"
+#include <ostream>
 
 using namespace RiRi::Commands;
 

--- a/tests/units/commands/test_update.cpp
+++ b/tests/units/commands/test_update.cpp
@@ -211,7 +211,6 @@ TEST_SUITE("Commands") {
             CHECK(response.ok() == false);
             CHECK(response.code() == RiRi::StatusCode::WARN_ZERO_NODES_PROVIDED);
             CHECK(response.errorCount() == 0);
-            // OKAY PAUSE. This shouldn't be like this.
         }
 
         // 7

--- a/tests/units/test_core.cpp
+++ b/tests/units/test_core.cpp
@@ -77,7 +77,7 @@ TEST_CASE("(INTERNAL) Data Manager") {
         CHECK(updateValue("_key", "shadowslure") == false);
     }
 
-    SUBCASE("updateValue of of existing key with same value") {
+    SUBCASE("updateValue of existing key with same value") {
         RiRi::RapidNode node{"_key", "RiRi"};
         setValue(std::move(node.key), std::move(node.value));
 

--- a/tests/units/test_core.cpp
+++ b/tests/units/test_core.cpp
@@ -77,6 +77,17 @@ TEST_CASE("(INTERNAL) Data Manager") {
         CHECK(updateValue("_key", "shadowslure") == false);
     }
 
+    SUBCASE("updateValue of of existing key with same value") {
+        RiRi::RapidNode node{"_key", "RiRi"};
+        setValue(std::move(node.key), std::move(node.value));
+
+        REQUIRE(updateValue("_key", "RiRi") == true);
+
+        CHECK(*unpack_as<std::string>(getValue("_key")) == "RiRi");
+        CHECK(size() == 1);
+
+    }
+
     SUBCASE("clearMap") {
         setValue("_main_key", RiRi::RapidDataType{"ad4rsh2701"});
         setValue("_alt_key", RiRi::RapidDataType{"ShadowsLure"});

--- a/tests/units/test_utils.cpp
+++ b/tests/units/test_utils.cpp
@@ -125,7 +125,7 @@ TEST_SUITE("UTILS") {
         // 7
         SUBCASE ("to_string") {
 
-            // (RapidDataTpye*)
+            // (RapidDataType*)
             CHECK(to_string(&node_str.value) == std::string("value"));
             CHECK(to_string(&node_int.value) == std::string("37"));
             CHECK(to_string(&node_double.value) == std::string("3.14"));

--- a/tests/units/test_utils.cpp
+++ b/tests/units/test_utils.cpp
@@ -1,0 +1,142 @@
+#include "doctest.h"
+#include "riri/utils/Accessors.hpp"
+#include "riri/RapidTypes.hpp"
+#include <cstdint>
+#include <string>
+#include <ostream>
+
+using namespace RiRi::Utils;
+
+TEST_SUITE("UTILS") {
+
+    TEST_CASE("ACCESSORS") {
+
+        auto node_str = RiRi::RapidNode{"key", "value"};
+        auto node_int = RiRi::RapidNode{"key", std::int64_t{37}};
+        auto node_double = RiRi::RapidNode{"key", 3.14};
+        auto node_bool = RiRi::RapidNode{"key", false};
+
+        RiRi::RapidNode nodes[] {node_str, node_int, node_double, node_bool};
+
+        // 1
+        SUBCASE("unpack_as<string>") {
+            int i = 0;
+            for (auto& [_, val]: nodes) {
+                if (i == 0) {
+                    REQUIRE(unpack_as<std::string>(&val) != nullptr);
+                    CHECK(*unpack_as<std::string>(&val) == "value");
+                }
+                else {
+                    REQUIRE(unpack_as<std::string>(&val) == nullptr);
+                }
+                i++;
+            }
+        }
+
+        // 2
+        SUBCASE("unpack_as<int64_t>") {
+            int i = 0;
+            for (auto& [_, val]: nodes) {
+                if (i == 1) {
+                    REQUIRE(unpack_as<std::int64_t>(&val) != nullptr);
+                    CHECK(*unpack_as<std::int64_t>(&val) == 37);
+                }
+                else {
+                    REQUIRE(unpack_as<std::int64_t>(&val) == nullptr);
+                }
+                i++;
+            }
+        }
+
+        // 3
+        SUBCASE("unpack_as<double>") {
+            int i = 0;
+            for (auto& [_, val]: nodes) {
+                if (i == 2) {
+                    REQUIRE(unpack_as<double>(&val) != nullptr);
+                    CHECK(*unpack_as<double>(&val) == 3.14);
+                }
+                else {
+                    REQUIRE(unpack_as<double>(&val) == nullptr);
+                }
+                i++;
+            }
+        }
+
+        // 4
+        SUBCASE("unpack_as<bool>") {
+            int i = 0;
+            for (auto& [_, val]: nodes) {
+                if (i == 3) {
+                    REQUIRE(unpack_as<bool>(&val) != nullptr);
+                    CHECK(*unpack_as<bool>(&val) == false);
+                }
+                else {
+                    REQUIRE(unpack_as<bool>(&val) == nullptr);
+                }
+                i++;
+            }
+        }
+
+        // 5
+        // this subcase is basically a hack/workaround for testing
+        // the types like ResultOrStatus, which are present in RaReSy
+        // (used internally).
+        SUBCASE("unpack_field") {
+
+            // The variants are formatted exactly as in RaReSy
+
+            // std::variant<const RapidDataType*, StatusCode>;
+            detail::VariantLike_rdt data {&node_str.value};
+            REQUIRE(unpack_field(&data) != nullptr);
+            CHECK(*unpack_field(&data) == node_str.value);
+
+            // std::variant<std::string_view, StatusCode>;
+            detail::VariantLike_strv data_2 {node_str.key};
+            REQUIRE(unpack_field(&data_2) != nullptr);
+            CHECK(*unpack_field(&data_2) == node_str.key);
+
+            // std::variant<std::monostate, StatusCode>;
+            detail::VariantLike_mono data_3 {};
+            REQUIRE(unpack_field(&data_3) != nullptr);
+            CHECK(*unpack_field(&data_3) == std::monostate());
+
+        }   // done so to check the helpers without getting raresy here
+
+        // 6
+        // same logic here
+        SUBCASE("unpack_field_code") {
+            // std::variant<const RapidDataType*, StatusCode>;
+            detail::VariantLike_rdt data {RiRi::StatusCode::ERR_UNKNOWN};
+            REQUIRE(unpack_field_code(&data) != nullptr);
+            CHECK(*unpack_field_code(&data) == RiRi::StatusCode::ERR_UNKNOWN);
+
+            // std::variant<std::string_view, StatusCode>;
+            detail::VariantLike_strv data_2 {RiRi::StatusCode::ERR_UNKNOWN};
+            REQUIRE(unpack_field_code(&data_2) != nullptr);
+            CHECK(*unpack_field_code(&data_2) == RiRi::StatusCode::ERR_UNKNOWN);
+
+            // std::variant<std::monostate, StatusCode>;
+            detail::VariantLike_mono data_3 {RiRi::StatusCode::ERR_UNKNOWN};
+            REQUIRE(unpack_field_code(&data_3) != nullptr);
+            CHECK(*unpack_field_code(&data_3) == RiRi::StatusCode::ERR_UNKNOWN);
+        }
+
+        // 7
+        SUBCASE ("to_string") {
+
+            // (RapidDataTpye*)
+            CHECK(to_string(&node_str.value) == std::string("value"));
+            CHECK(to_string(&node_int.value) == std::string("37"));
+            CHECK(to_string(&node_double.value) == std::string("3.14"));
+            CHECK(to_string(&node_bool.value) == std::string("false"));
+
+            // (StatusCode) TODO
+            // Hmm, we need a single source of truth for status codes.
+            // With the current impl. I can't think of any way to check
+            // if all the corresponding code strings are present in to_string.
+            // For now, we will just check what an undefined status code does
+            CHECK(to_string(static_cast<RiRi::StatusCode>(555)) == "UNKNOWN-CODE-555");
+        }
+    }
+}


### PR DESCRIPTION
Progresses #45 (Release 0.0.2 checklist)

The test coverage is added for:
- Upper Command Layers (files covered: `Commands.hpp`, `src/commands/*.cpp`)
- Utilities (file covered: `Accessors.hpp`)

Total Test Cases: **11**
Total Assertions: **10000** (exact, lol)

```bash
[doctest] doctest version is "2.5.0"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:    11 |    11 passed | 0 failed | 0 skipped
[doctest] assertions: 10000 | 10000 passed | 0 failed |
[doctest] Status: SUCCESS!
``` 

### Other Changes
- Added a new warn code `WARN_ZERO_NODES_PROVIDED` (201) for handling cases when empty span of `RapidNodes` are passed to commands.
- Adding on, the commands now handle the edge case of empty span, and return early while setting the status code to the new WARN code.